### PR TITLE
Drop byte order mark (BOM) for consistency and compatibility

### DIFF
--- a/exportify.html
+++ b/exportify.html
@@ -108,7 +108,7 @@
   <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-mockjax/1.6.2/jquery.mockjax.min.js"></script>
   <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/jszip/2.5.0/jszip.min.js"></script>
-  <script src="//cdn.rawgit.com/eligrey/FileSaver.js/babc6d9d8fc60e667ddeafb7a7d3b844ce761ab5/FileSaver.min.js"></script>
+  <script src="//cdn.rawgit.com/eligrey/FileSaver.js/631047d72f4e89fab6059203ca71eb064a0bb031/FileSaver.min.js"></script>
 
   <!-- React.js -->
   <script src="//cdnjs.cloudflare.com/ajax/libs/react/0.13.3/react.js"></script>

--- a/exportify.js
+++ b/exportify.js
@@ -289,8 +289,8 @@ var PlaylistsExporter = {
 var PlaylistExporter = {
   export: function(access_token, playlist) {
     this.csvData(access_token, playlist).then(function(data) {
-      var blob = new Blob(["\uFEFF" + data], { type: "text/csv;charset=utf-8" });
-      saveAs(blob, this.fileName(playlist));
+      var blob = new Blob([ data ], { type: "text/csv;charset=utf-8" });
+      saveAs(blob, this.fileName(playlist), true);
     }.bind(this))
   },
 


### PR DESCRIPTION
In general, use of the byte order mark (BOM) is optional for Unicode encodings. And in UTF-8, which is used for the outputs of this project, it’s really *irrelevant*, since UTF-8 doesn’t have any concept of endianness. Further, it breaks backward compatibility with ASCII, which is otherwise one of the major strengths of the UTF-8 encoding. Next, it had actually been inserted *twice*, which is never correct. You added it manually, once, and the “FileSaver” library added it once again for all `text/*` MIME types. And finally, it’s inconsistent, because it had only been used in the single-playlist (CSV) exports from this project, but *not* in the multi-playlist (ZIP) exports. The most reasonable solution is to remove it entirely.