### PR TITLE
Drop tautology and ensure POSIX compliance with trailing newline

### DIFF
--- a/exportify.js
+++ b/exportify.js
@@ -350,7 +350,7 @@ var PlaylistExporter = {
       csvContent = '';
       tracks.forEach(function(infoArray, index){
         dataString = infoArray.join(",");
-        csvContent += index < tracks.length ? dataString+ "\n" : dataString;
+        csvContent += dataString + "\n";
       });
 
       return csvContent;


### PR DESCRIPTION
If you `forEach` over `tracks`, isn’t `index`, being zero-based, always less than `tracks.length`?

That’s fine, because that way, we have POSIX compliance with a trailing newline, at least.

But we can remove the condition.