### PR TITLE
Properly escape all fields for safe use as values in CSV documents

### DIFF
--- a/exportify.js
+++ b/exportify.js
@@ -328,7 +328,7 @@ var PlaylistExporter = {
             item.track.duration_ms,
             item.added_by == null ? '' : item.added_by.uri,
             item.added_at
-          ].map(function(track) { return '"' + track + '"'; })
+          ];
         });
       });
 
@@ -348,8 +348,8 @@ var PlaylistExporter = {
       ]);
 
       csvContent = '';
-      tracks.forEach(function(infoArray, index){
-        dataString = infoArray.join(",");
+      tracks.forEach(function (row, index){
+        dataString = row.map(function (cell) { return '"' + String(cell).replace(/"/g, '""') + '"'; }).join(",");
         csvContent += index < tracks.length ? dataString+ "\n" : dataString;
       });
 


### PR DESCRIPTION
While the CSV format is not *completely* trivial, it’s not terribly complex, either.

In the absence of a standard specification that is commonly agreed upon, with several variants and conventions instead, the most common approach for *safe* CSV encoding with proper escaping is as follows:

Enclosing a field in double quotes is generally optional (and always allowed). If a field contains one of the three metacharacters, i.e. a newline (line break), a comma, or a double quote, that field *must* be enclosed in double quotes. Then, any double quotes *inside* the field are escaped by duplicating each quote.

That’s quite simple already. And if we decide that we *always* wrap fields in double quotes, which is perfectly valid, even the little complexity of determining when to wrap and when not to wrap goes away.

Thus, with the proper escaping applied, the export does always produce valid CSV.

Additionally, this proposed change gets rid of *two* poorly named parameters and moves the escaping to a place where it makes even more sense, right at the point where CSV output is compiled. This also escapes the headers automatically, which guarantees consistency and allows for special characters in the headers in the future (or in custom modifications at any time).