### PR TITLE
Considerably improve support for non-English playlist names for files

### DIFF
--- a/exportify.js
+++ b/exportify.js
@@ -358,7 +358,7 @@ var PlaylistExporter = {
   },
 
   fileName: function(playlist) {
-    return playlist.name.replace(/[^a-z0-9\- ]/gi, '').replace(/[ ]/gi, '_').toLowerCase() + ".csv";
+    return playlist.name.replace(/[\x00-\x1F\x7F/\\<>:;"|=,.?*[\] ]+/g, "_").toLowerCase() + ".csv";
   }
 }
 


### PR DESCRIPTION
The current regex for invalid characters in filenames is the following:

```
/[^a-z0-9\- ]/gi
```

That may appear safe and acceptable, but for anything non-English, this produces terribly ugly filenames and discards valuable information without a need for that.

Non-English users may have playlist names that look like the following:

```
Éärth, Wínd & Fire
```

That would still be a very “friendly” name for the regex above. Nevertheless, the generated filename based on that playlist name would become as ugly as this:

```
rth_wnd__fire.csv
```

(Note also the double underscore!)

Let’s not even talk about non-Latin alphabets, e.g. Chinese, where you’ll lose practically every character in the playlist name.

This proposed change would improve the situation for all non-English users and those using special characters in their playlist names. Considering the playlist name above, it would instead produce the following filename:

```
éärth_wínd_&_fire.csv
```

That filename should still be valid on Windows, macOS, Linux, Android and iOS, at least.