### PR TITLE
Add support for 'Saved tracks' from 'Your music' library

### DIFF
--- a/exportify.js
+++ b/exportify.js
@@ -10,7 +10,7 @@ window.Helpers = {
     window.location = "https://accounts.spotify.com/authorize" +
       "?client_id=" + client_id +
       "&redirect_uri=" + encodeURIComponent([location.protocol, '//', location.host, location.pathname].join('')) +
-      "&scope=playlist-read-private%20playlist-read-collaborative" +
+      "&scope=playlist-read-private%20playlist-read-collaborative%20user-library-read" +
       "&response_type=token";
   },
 
@@ -87,6 +87,26 @@ var PlaylistTable = React.createClass({
         playlists = $.merge([arguments[0][0]], arguments[1][0].items);
       }
 
+      // Show library of saved tracks if viewing first page
+      if (firstPage) {
+        playlists.unshift({
+          "id": "saved",
+          "name": "Saved",
+          "public": false,
+          "collaborative": false,
+          "owner": {
+            "id": userId,
+            "uri": "spotify:user:" + userId
+          },
+          "tracks": {
+            "href": "https://api.spotify.com/v1/me/tracks",
+            "limit": 50,
+            "total": 2500 // TODO: get rid of hard-coded library size
+          },
+          "uri": "spotify:user:" + userId + ":saved"
+        });
+      }
+
       if (this.isMounted()) {
         this.setState({
           playlists: playlists,
@@ -155,7 +175,7 @@ var PlaylistRow = React.createClass({
   },
 
   renderIcon: function(playlist) {
-    if (playlist.name == 'Starred') {
+    if (playlist.name == 'Starred' || playlist.name == 'Saved') {
       return <i className="glyphicon glyphicon-star" style={{ color: 'gold' }}></i>;
     } else {
       return <i className="fa fa-music"></i>;
@@ -264,6 +284,17 @@ var PlaylistsExporter = {
           playlists = arguments[0].items
         }
 
+        // Add library of saved tracks
+        playlists.unshift({
+          "id": "saved",
+          "name": "Saved",
+          "tracks": {
+            "href": "https://api.spotify.com/v1/me/tracks",
+            "limit": 50,
+            "total": 2500 // TODO: get rid of hard-coded library size
+          },
+        });
+
         $(playlists).each(function(i, playlist) {
           playlistFileNames.push(PlaylistExporter.fileName(playlist));
           playlistExports.push(PlaylistExporter.csvData(access_token, playlist));
@@ -296,7 +327,7 @@ var PlaylistExporter = {
 
   csvData: function(access_token, playlist) {
     var requests = [];
-    var limit = 100;
+    var limit = playlist.tracks.limit || 100;
 
     for (var offset = 0; offset < playlist.tracks.total; offset = offset + limit) {
       requests.push(


### PR DESCRIPTION
As far back as in July 2014, Spotify [introduced](https://developer.spotify.com/news-stories/2014/07/23/web-api-music-tracks-endpoints-released/) support for your personal library called “Your music” where you can have “Saved tracks”. The documentation for that endpoint is [here](https://developer.spotify.com/web-api/get-users-saved-tracks/).

The “starred” tracks have been an undocumented feature and have since been phased out in the official clients, where they have been [replaced](https://github.com/spotify/web-api/issues/39) with the “Your music” collection. But this proposed change doesn’t touch them, and keeps them for backward compatibility.

The feature requires *one* new permission (or scope), which is *read-only*, like the two others already in use:

```
user-library-read
```

Without this additional scope, this feature is obviously not possible.

The upgrade process is seamless, and users are asked for authorization again, where the single new permission is marked as such.

It works with both single-playlist (CSV) and multi-playlist (ZIP) exports.

There’s only one flaw, as far as I can see. That is a major flaw, however: This implementation currently uses a hard-coded library size of 2,500 songs. If you have more songs saved, the additional songs will not be exported. If you have fewer, everything will work fine, but superfluous XHR requests will be made.

Spotify itself apparently has a hard limit of 10,000 songs that you can save to your collection. But increasing the hard-coded size to 10,000 is certainly not the solution, as it wastes even more XHR requests for most users.