### PR TITLE
Fix Github Pages binary distribution warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ os: osx
 
 before_install:
   - brew cask install phantomjs
-  - git clone git://github.com/n1k0/casperjs.git casperjs
-  - export PATH=`pwd`/casperjs/bin/:$PATH
+  - git clone git://github.com/n1k0/casperjs.git /tmp/casperjs
+  - export PATH=/tmp/casperjs/bin/:$PATH
 
 before_script:
   - phantomjs --version


### PR DESCRIPTION
> The page build completed successfully, but returned the following warning for the `gh-pages` branch:
>
> It looks like you're using GitHub Pages to distribute binary files. We strongly suggest that you use releases to ship projects on GitHub. Releases are GitHub's way of packaging and providing software to your users. You can think of it as a replacement to using downloads to provide software. We found the following file(s) which may be a good candidate for releases: casperjs/bin/casperjs.exe. For more information, see https://docs.github.com/github/administering-a-repository/about-releases.