### PR TITLE
Add rate limiting and export progress tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/react-bootstrap": "^0.32.24",
     "@types/react-dom": "^16.9.8",
     "bootstrap": "3.3.7",
+    "bottleneck": "^2.19.5",
     "file-saver": "^2.0.2",
     "jquery": "2.1.4",
     "jszip": "^3.5.0",

--- a/src/App.scss
+++ b/src/App.scss
@@ -15,16 +15,34 @@
 h1 a { color: black; }
 h1 a:hover { color: black; text-decoration: none; }
 
-nav.paginator:nth-child(1) {
-  margin-top: -74px;
-}
-
 table {
   float: left;
 }
 
 #playlists {
   display: none;
+}
+
+#playlistsHeader {
+  display: flex;
+  flex-direction: row-reverse;
+
+  .progress {
+    flex-grow: 1;
+    margin: 20px 20px 20px 0;
+    height: 30px;
+
+    .progress-bar {
+      white-space: nowrap;
+      padding: 4px 10px;
+      text-align: left;
+
+      // Transitioning when resetting looks weird
+      &[aria-valuenow="1"] {
+        transition: none;
+      }
+    }
+  }
 }
 
 @keyframes spinner {

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -34,7 +34,7 @@ describe("authentication request", () => {
 
 describe("authentication return", () => {
   beforeAll(() => {
-    window.location = { hash: "#access_token=TEST_TOKEN" }
+    window.location = { hash: "#access_token=TEST_ACCESS_TOKEN" }
   })
 
   test("renders playlist component on return from Spotify with auth token", () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
       <p style={{ marginTop: "50px" }}>It should still be possible to export individual playlists, particularly when using your own Spotify application.</p>
     </div>
   } else if (key.has('access_token')) {
-    view = <PlaylistTable access_token={key.get('access_token')} />
+    view = <PlaylistTable accessToken={key.get('access_token')} />
   } else {
     view = <Login />
   }

--- a/src/components/PlaylistExporter.jsx
+++ b/src/components/PlaylistExporter.jsx
@@ -1,83 +1,69 @@
-import $ from "jquery" // TODO: Remove jQuery dependency
 import { saveAs } from "file-saver"
 
 import { apiCall } from "helpers"
 
 // Handles exporting a single playlist as a CSV file
 var PlaylistExporter = {
-  export: function(access_token, playlist) {
-    this.csvData(access_token, playlist).then((data) => {
+  export: function(accessToken, playlist) {
+    this.csvData(accessToken, playlist).then((data) => {
       var blob = new Blob([ data ], { type: "text/csv;charset=utf-8" });
       saveAs(blob, this.fileName(playlist), true);
     })
   },
 
-  csvData: function(access_token, playlist) {
+  csvData: async function(accessToken, playlist) {
     var requests = [];
     var limit = playlist.tracks.limit || 100;
 
+    // Add tracks
     for (var offset = 0; offset < playlist.tracks.total; offset = offset + limit) {
-      requests.push(
-        apiCall(`${playlist.tracks.href.split('?')[0]}?offset=${offset}&limit=${limit}`, access_token)
-      )
+      requests.push(`${playlist.tracks.href.split('?')[0]}?offset=${offset}&limit=${limit}`)
     }
 
-    return $.when.apply($, requests).then(function() {
-      var responses = [];
+    let promises = requests.map((request) => {
+      return apiCall(request, accessToken)
+    })
 
-      // Handle either single or multiple responses
-      if (typeof arguments[0] != 'undefined') {
-        if (typeof arguments[0].href == 'undefined') {
-          responses = Array.prototype.slice.call(arguments).map(function(a) { return a[0] });
-        } else {
-          responses = [arguments[0]];
-        }
-      }
+    let tracks = (await Promise.all(promises)).flatMap(response => {
+      return response.items.map(item => {
+        return item.track && [
+          item.track.uri,
+          item.track.name,
+          item.track.artists.map(function(artist) { return artist.uri }).join(', '),
+          item.track.artists.map(function(artist) { return String(artist.name).replace(/,/g, "\\,") }).join(', '),
+          item.track.album.uri,
+          item.track.album.name,
+          item.track.disc_number,
+          item.track.track_number,
+          item.track.duration_ms,
+          item.added_by == null ? '' : item.added_by.uri,
+          item.added_at
+        ];
+      }).filter(e => e)
+    })
 
-      var tracks = responses.map(function(response) {
-        return response.items.map(function(item) {
-          return item.track && [
-            item.track.uri,
-            item.track.name,
-            item.track.artists.map(function(artist) { return artist.uri }).join(', '),
-            item.track.artists.map(function(artist) { return String(artist.name).replace(/,/g, "\\,") }).join(', '),
-            item.track.album.uri,
-            item.track.album.name,
-            item.track.disc_number,
-            item.track.track_number,
-            item.track.duration_ms,
-            item.added_by == null ? '' : item.added_by.uri,
-            item.added_at
-          ];
-        }).filter(e => e);
-      });
+    tracks.unshift([
+      "Track URI",
+      "Track Name",
+      "Artist URI",
+      "Artist Name",
+      "Album URI",
+      "Album Name",
+      "Disc Number",
+      "Track Number",
+      "Track Duration (ms)",
+      "Added By",
+      "Added At"
+    ]);
 
-      // Flatten the array of pages
-      tracks = $.map(tracks, function(n) { return n })
+    let csvContent = '';
 
-      tracks.unshift([
-        "Track URI",
-        "Track Name",
-        "Artist URI",
-        "Artist Name",
-        "Album URI",
-        "Album Name",
-        "Disc Number",
-        "Track Number",
-        "Track Duration (ms)",
-        "Added By",
-        "Added At"
-      ]);
-
-      let csvContent = '';
-
-      tracks.forEach(function(row, index){
-        let dataString = row.map(function (cell) { return '"' + String(cell).replace(/"/g, '""') + '"'; }).join(",");
-        csvContent += dataString + "\n";
-      });
-
-      return csvContent;
+    tracks.forEach(function(row, index){
+      let dataString = row.map(function (cell) { return '"' + String(cell).replace(/"/g, '""') + '"'; }).join(",");
+      csvContent += dataString + "\n";
     });
+
+    return csvContent;
   },
 
   fileName: function(playlist) {

--- a/src/components/PlaylistRow.jsx
+++ b/src/components/PlaylistRow.jsx
@@ -5,7 +5,7 @@ import PlaylistExporter from "./PlaylistExporter"
 
 class PlaylistRow extends React.Component {
   exportPlaylist = () => {
-    PlaylistExporter.export(this.props.access_token, this.props.playlist);
+    PlaylistExporter.export(this.props.accessToken, this.props.playlist);
   }
 
   renderTickCross(condition) {

--- a/src/components/PlaylistTable.jsx
+++ b/src/components/PlaylistTable.jsx
@@ -21,35 +21,26 @@ class PlaylistTable extends React.Component {
     var userId = '';
     var firstPage = typeof url === 'undefined' || url.indexOf('offset=0') > -1;
 
-    apiCall("https://api.spotify.com/v1/me", this.props.access_token).then((response) => {
+    apiCall("https://api.spotify.com/v1/me", this.props.accessToken).then((response) => {
       userId = response.id;
 
       // Show liked tracks playlist if viewing first page
       if (firstPage) {
-        return $.when.apply($, [
-          apiCall(
-            "https://api.spotify.com/v1/users/" + userId + "/tracks",
-            this.props.access_token
-          ),
+        return Promise.all([
           apiCall(
             "https://api.spotify.com/v1/users/" + userId + "/playlists",
-            this.props.access_token
+            this.props.accessToken
+          ),
+          apiCall(
+            "https://api.spotify.com/v1/users/" + userId + "/tracks",
+            this.props.accessToken
           )
         ])
       } else {
-        return apiCall(url, this.props.access_token);
+        return Promise.all([apiCall(url, this.props.accessToken)])
       }
-    }).done((...args) => {
-      var response;
-      var playlists = [];
-
-      if (args[1] === 'success') {
-        response = args[0];
-        playlists = args[0].items;
-      } else {
-        response = args[1][0];
-        playlists = args[1][0].items;
-      }
+    }).then(([playlistsResponse, likedTracksResponse]) => {
+      let playlists = playlistsResponse.items;
 
       // Show library of saved tracks if viewing first page
       if (firstPage) {
@@ -65,35 +56,34 @@ class PlaylistTable extends React.Component {
           },
           "tracks": {
             "href": "https://api.spotify.com/v1/me/tracks",
-            "limit": args[0][0].limit,
-            "total": args[0][0].total
+            "limit": likedTracksResponse.limit,
+            "total": likedTracksResponse.total
           },
           "uri": "spotify:user:" + userId + ":saved"
         });
 
         // FIXME: Handle unmounting
         this.setState({
-          likedSongsLimit: args[0][0].limit,
-          likedSongsCount: args[0][0].total
+          likedSongsLimit: likedTracksResponse.limit,
+          likedSongsCount: likedTracksResponse.total
         })
       }
 
       // FIXME: Handle unmounting
       this.setState({
         playlists: playlists,
-        playlistCount: response.total,
-        nextURL: response.next,
-        prevURL: response.previous
+        playlistCount: playlistsResponse.total,
+        nextURL: playlistsResponse.next,
+        prevURL: playlistsResponse.previous
       });
 
       $('#playlists').fadeIn();
-      $('#subtitle').text((response.offset + 1) + '-' + (response.offset + response.items.length) + ' of ' + response.total + ' playlists for ' + userId)
-
+      $('#subtitle').text((playlistsResponse.offset + 1) + '-' + (playlistsResponse.offset + playlistsResponse.items.length) + ' of ' + playlistsResponse.total + ' playlists for ' + userId)
     })
   }
 
   exportPlaylists = () => {
-    PlaylistsExporter.export(this.props.access_token, this.state.playlistCount, this.state.likedSongsLimit, this.state.likedSongsCount);
+    PlaylistsExporter.export(this.props.accessToken, this.state.playlistCount, this.state.likedSongsLimit, this.state.likedSongsCount);
   }
 
   componentDidMount() {
@@ -123,7 +113,7 @@ class PlaylistTable extends React.Component {
             </thead>
             <tbody>
               {this.state.playlists.map((playlist, i) => {
-                return <PlaylistRow playlist={playlist} key={playlist.id} access_token={this.props.access_token}/>
+                return <PlaylistRow playlist={playlist} key={playlist.id} accessToken={this.props.accessToken}/>
               })}
             </tbody>
           </table>

--- a/src/components/PlaylistTable.test.jsx
+++ b/src/components/PlaylistTable.test.jsx
@@ -27,7 +27,7 @@ afterEach(() => {
 
 // Use a snapshot test to ensure exact component rendering
 test("playlist loading", async () => {
-  const component = renderer.create(<PlaylistTable />)
+  const component = renderer.create(<PlaylistTable accessToken="TEST_ACCESS_TOKEN" />)
   const instance = component.getInstance()
 
   await waitFor(() => {
@@ -42,7 +42,7 @@ describe("single playlist exporting", () => {
     const saveAsMock = jest.spyOn(FileSaver, "saveAs")
     saveAsMock.mockImplementation(jest.fn())
 
-    render(<PlaylistTable />);
+    render(<PlaylistTable accessToken="TEST_ACCESS_TOKEN" />);
 
     await waitFor(() => {
       expect(screen.getByText(/Export All/)).toBeInTheDocument()
@@ -76,7 +76,7 @@ describe("single playlist exporting", () => {
     const saveAsMock = jest.spyOn(FileSaver, "saveAs")
     saveAsMock.mockImplementation(jest.fn())
 
-    render(<PlaylistTable />);
+    render(<PlaylistTable accessToken="TEST_ACCESS_TOKEN" />);
 
     await waitFor(() => {
       expect(screen.getByText(/Export All/)).toBeInTheDocument()
@@ -112,7 +112,7 @@ test("exporting of all playlist", async () => {
   const jsZipGenerateAsync = jest.spyOn(JSZip.prototype, 'generateAsync')
   jsZipGenerateAsync.mockResolvedValue("zip_content")
 
-  render(<PlaylistTable />);
+  render(<PlaylistTable accessToken="TEST_ACCESS_TOKEN" />);
 
   await waitFor(() => {
     expect(screen.getByText(/Export All/)).toBeInTheDocument()

--- a/src/components/PlaylistsExporter.jsx
+++ b/src/components/PlaylistsExporter.jsx
@@ -1,3 +1,5 @@
+import React from "react"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { saveAs } from "file-saver"
 import JSZip from "jszip"
 
@@ -5,9 +7,8 @@ import PlaylistExporter from "./PlaylistExporter"
 import { apiCall } from "helpers"
 
 // Handles exporting all playlist data as a zip file
-let PlaylistsExporter = {
-  export: async function(accessToken, playlistCount, likedSongsLimit, likedSongsCount) {
-
+class PlaylistsExporter extends React.Component {
+  async export(accessToken, playlistCount, likedSongsLimit, likedSongsCount) {
     var playlistFileNames = []
     var playlistCsvExports = []
 
@@ -24,6 +25,7 @@ let PlaylistsExporter = {
 
       let playlistPromises = requests.map((request, index) => {
         return apiCall(request, accessToken).then((response) => {
+          this.props.onLoadedPlaylistsCountChanged((index + 1) * limit)
           return response
         })
       })
@@ -45,6 +47,7 @@ let PlaylistsExporter = {
         return PlaylistExporter.csvData(accessToken, playlist).then((csvData) => {
           playlistFileNames.push(PlaylistExporter.fileName(playlist))
           playlistCsvExports.push(csvData)
+          this.props.onExportedPlaylistsCountChanged(index + 1)
         })
       })
 
@@ -60,6 +63,16 @@ let PlaylistsExporter = {
         saveAs(content, "spotify_playlists.zip");
       })
     })
+  }
+
+  exportPlaylists = () => {
+    this.export(this.props.accessToken, this.props.playlistCount, this.props.likedSongs.limit, this.props.likedSongs.count)
+  }
+
+  render() {
+    return <button className="btn btn-default btn-xs" type="submit" onClick={this.exportPlaylists}>
+      <span className="fa fa-file-archive"></span><FontAwesomeIcon icon={['far', 'file-archive']}/> Export All
+    </button>
   }
 }
 

--- a/src/components/PlaylistsExporter.jsx
+++ b/src/components/PlaylistsExporter.jsx
@@ -1,4 +1,3 @@
-import $ from "jquery" // TODO: Remove jQuery dependency
 import { saveAs } from "file-saver"
 import JSZip from "jszip"
 
@@ -7,10 +6,12 @@ import { apiCall } from "helpers"
 
 // Handles exporting all playlist data as a zip file
 let PlaylistsExporter = {
-  export: function(access_token, playlistCount, likedSongsLimit, likedSongsCount) {
-    var playlistFileNames = [];
+  export: async function(accessToken, playlistCount, likedSongsLimit, likedSongsCount) {
 
-    apiCall("https://api.spotify.com/v1/me", access_token).then(function(response) {
+    var playlistFileNames = []
+    var playlistCsvExports = []
+
+    apiCall("https://api.spotify.com/v1/me", accessToken).then(async (response) => {
       var limit = 20;
       var userId = response.id;
       var requests = [];
@@ -18,59 +19,47 @@ let PlaylistsExporter = {
       // Add playlists
       for (var offset = 0; offset < playlistCount; offset = offset + limit) {
         var url = "https://api.spotify.com/v1/users/" + userId + "/playlists";
-        requests.push(
-          apiCall(`${url}?offset=${offset}&limit=${limit}`, access_token)
-        )
+        requests.push(`${url}?offset=${offset}&limit=${limit}`)
       }
 
-      $.when.apply($, requests).then(function() {
-        var playlists = [];
-        var playlistExports = [];
-
-        // Handle either single or multiple responses
-        if (typeof arguments[0].href == 'undefined') {
-          $(arguments).each(function(i, response) {
-            if (typeof response[0].items === 'undefined') {
-              // Single playlist
-              playlists.push(response[0]);
-            } else {
-              // Page of playlists
-              $.merge(playlists, response[0].items);
-            }
-          })
-        } else {
-          playlists = arguments[0].items
-        }
-
-        // Add library of saved tracks
-        playlists.unshift({
-          "id": "liked",
-          "name": "Liked",
-          "tracks": {
-            "href": "https://api.spotify.com/v1/me/tracks",
-            "limit": likedSongsLimit,
-            "total": likedSongsCount
-          },
-        });
-
-        $(playlists).each(function(i, playlist) {
-          playlistFileNames.push(PlaylistExporter.fileName(playlist));
-          playlistExports.push(PlaylistExporter.csvData(access_token, playlist));
-        });
-
-        return $.when.apply($, playlistExports);
-      }).then(function() {
-        var zip = new JSZip();
-
-        $(arguments).each(function(i, response) {
-          zip.file(playlistFileNames[i], response)
-        });
-
-        zip.generateAsync({ type: "blob" }).then(function(content) {
-          saveAs(content, "spotify_playlists.zip");
+      let playlistPromises = requests.map((request, index) => {
+        return apiCall(request, accessToken).then((response) => {
+          return response
         })
-      });
-    });
+      })
+
+      let playlists = (await Promise.all(playlistPromises)).flatMap(response => response.items)
+
+      // Add library of saved tracks
+      playlists.unshift({
+        "id": "liked",
+        "name": "Liked",
+        "tracks": {
+          "href": "https://api.spotify.com/v1/me/tracks",
+          "limit": likedSongsLimit,
+          "total": likedSongsCount
+        },
+      })
+
+      let trackPromises = playlists.map((playlist, index) => {
+        return PlaylistExporter.csvData(accessToken, playlist).then((csvData) => {
+          playlistFileNames.push(PlaylistExporter.fileName(playlist))
+          playlistCsvExports.push(csvData)
+        })
+      })
+
+      await Promise.all(trackPromises)
+
+      var zip = new JSZip()
+
+      playlistCsvExports.forEach(function(csv, i) {
+        zip.file(playlistFileNames[i], csv)
+      })
+
+      zip.generateAsync({ type: "blob" }).then(function(content) {
+        saveAs(content, "spotify_playlists.zip");
+      })
+    })
   }
 }
 

--- a/src/components/__snapshots__/PlaylistTable.test.jsx.snap
+++ b/src/components/__snapshots__/PlaylistTable.test.jsx.snap
@@ -4,44 +4,48 @@ exports[`playlist loading 1`] = `
 <div
   id="playlists"
 >
-  <nav
-    className="paginator text-right"
+  <div
+    id="playlistsHeader"
   >
-    <ul
-      className="pagination pagination-sm"
+    <nav
+      className="paginator text-right"
     >
-      <li
-        className="disabled"
+      <ul
+        className="pagination pagination-sm"
       >
-        <a
-          aria-label="Previous"
-          href="#"
-          onClick={[Function]}
+        <li
+          className="disabled"
         >
-          <span
-            aria-hidden="true"
+          <a
+            aria-label="Previous"
+            href="#"
+            onClick={[Function]}
           >
-            «
-          </span>
-        </a>
-      </li>
-      <li
-        className=""
-      >
-        <a
-          aria-label="Next"
-          href="#"
-          onClick={[Function]}
+            <span
+              aria-hidden="true"
+            >
+              «
+            </span>
+          </a>
+        </li>
+        <li
+          className=""
         >
-          <span
-            aria-hidden="true"
+          <a
+            aria-label="Next"
+            href="#"
+            onClick={[Function]}
           >
-            »
-          </span>
-        </a>
-      </li>
-    </ul>
-  </nav>
+            <span
+              aria-hidden="true"
+            >
+              »
+            </span>
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
   <table
     className="table table-hover"
   >

--- a/src/mocks/handlers.jsx
+++ b/src/mocks/handlers.jsx
@@ -2,6 +2,10 @@ import { rest } from 'msw'
 
 export const handlers = [
   rest.get('https://api.spotify.com/v1/me', (req, res, ctx) => {
+    if (req.headers.get("Authorization") !== "Bearer TEST_ACCESS_TOKEN") {
+      return res(ctx.status(401), ctx.json({ message: 'Not authorized' }))
+    }
+
     return res(ctx.json(
       {
         "display_name" : "watsonbox",
@@ -22,6 +26,10 @@ export const handlers = [
   }),
 
   rest.get('https://api.spotify.com/v1/users/watsonbox/tracks', (req, res, ctx) => {
+    if (req.headers.get("Authorization") !== "Bearer TEST_ACCESS_TOKEN") {
+      return res(ctx.status(401), ctx.json({ message: 'Not authorized' }))
+    }
+
     return res(ctx.json(
       {
         "href" : "https://api.spotify.com/v1/me/tracks?offset=0&limit=20",
@@ -108,6 +116,10 @@ export const handlers = [
 
   // FIXME: Duplication of data
   rest.get('https://api.spotify.com/v1/me/tracks', (req, res, ctx) => {
+    if (req.headers.get("Authorization") !== "Bearer TEST_ACCESS_TOKEN") {
+      return res(ctx.status(401), ctx.json({ message: 'Not authorized' }))
+    }
+
     return res(ctx.json(
       {
         "href" : "https://api.spotify.com/v1/me/tracks?offset=0&limit=20",
@@ -193,6 +205,10 @@ export const handlers = [
   }),
 
   rest.get('https://api.spotify.com/v1/users/watsonbox/playlists', (req, res, ctx) => {
+    if (req.headers.get("Authorization") !== "Bearer TEST_ACCESS_TOKEN") {
+      return res(ctx.status(401), ctx.json({ message: 'Not authorized' }))
+    }
+
     return res(ctx.json(
       {
         "href" : "https://api.spotify.com/v1/users/watsonbox/playlists?offset=0&limit=20",
@@ -240,6 +256,10 @@ export const handlers = [
   }),
 
   rest.get('https://api.spotify.com/v1/playlists/4XOGDpHMrVoH33uJEwHWU5/tracks?offset=0&limit=10', (req, res, ctx) => {
+    if (req.headers.get("Authorization") !== "Bearer TEST_ACCESS_TOKEN") {
+      return res(ctx.status(401), ctx.json({ message: 'Not authorized' }))
+    }
+
     return res(ctx.json(
       {
         "href" : "https://api.spotify.com/v1/playlists/4XOGDpHMrVoH33uJEwHWU5/tracks?offset=0&limit=100",
@@ -430,6 +450,10 @@ export const handlers = [
 
 export const nullTrackHandlers = [
   rest.get('https://api.spotify.com/v1/playlists/4XOGDpHMrVoH33uJEwHWU5/tracks?offset=0&limit=10', (req, res, ctx) => {
+    if (req.headers.get("Authorization") !== "Bearer TEST_ACCESS_TOKEN") {
+      return res(ctx.status(401), ctx.json({ message: 'Not authorized' }))
+    }
+
     return res(ctx.json(
       {
         "href" : "https://api.spotify.com/v1/playlists/4XOGDpHMrVoH33uJEwHWU5/tracks?offset=0&limit=100",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2837,6 +2837,11 @@ bootstrap@3.3.7:
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
   integrity sha1-WjiTlFSfIzMIdaOxUGVldPip63E=
 
+bottleneck@^2.19.5:
+  version "2.19.5"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
+  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
This PR is in two parts: the rate limiting itself, and the progress UI.

### Rate Limiting

On the rate limiting topic, I reviewed the discussion [here](https://github.com/watsonbox/exportify/issues/12) and the proposal [here](https://github.com/watsonbox/exportify/pull/70). The problem with a throttling approach, as [mentioned](https://github.com/watsonbox/exportify/pull/70#issuecomment-724840011), is that two users with independently throttled requests can still encounter rate limiting due to the combined throughput. Additionally, it seems to me that we're also required to take a guess as to what level of throttling is acceptable (for example 10 requests per second), but since I can't find it in the documentation there's presumably no guarantee that this won't change either temporarily or permanently on their side.

The approach I've taken here is [the one described in their documentation](https://developer.spotify.com/documentation/web-api/):

> If Web API returns **status code 429**, it means that you have sent too many requests. When this happens, check the `Retry-After` header, where you will see a number displayed. This is the number of _seconds that you need to wait_, before you try your request again.

This way, it's the server itself that tells each client how long to wait, and so it should work fine across multiple users and is also resistant to any change in logic on Spotify's side. Furthermore, we can run requests as fast as we like until the server tells us otherwise, which should hopefully result in the fastest possible export times.

If we _do_ want to add basic throttling at any point, I've added the [bottleneck](https://github.com/SGrondin/bottleneck) job scheduler and rate limiter which can be simply and transparently configured to allow this. I've tried to isolate the rate limiting as much as possible from the app logic itself since it's really an implementation detail.

### Progress UI

The other part of this feature, which [I'd wanted to add sooner](https://github.com/watsonbox/exportify/issues/12#issuecomment-117762133), is a clearer indication of how long the export will take.

Here's how it looks:

![progress_screen_capture](https://user-images.githubusercontent.com/17737/98936576-6f660600-24e5-11eb-942d-41ebc182ec6e.gif)

I did think about adding some indication to the UI that the export was paused due to a rate limiting delay, but decided not to because I want to keep the interface as simple as possible, and:

1. The progress bar is animated when it's still running, showing visually that things are still happening.
2. In my admittedly limited testing, the delays requested from the server tended to be ~10s max, which doesn't feel too long in the context of a large export.