### PR TITLE
Fix null tracks playlist export bug

### DIFF
--- a/src/components/PlaylistExporter.jsx
+++ b/src/components/PlaylistExporter.jsx
@@ -36,7 +36,7 @@ var PlaylistExporter = {
 
       var tracks = responses.map(function(response) {
         return response.items.map(function(item) {
-          return [
+          return item.track && [
             item.track.uri,
             item.track.name,
             item.track.artists.map(function(artist) { return artist.uri }).join(', '),
@@ -49,7 +49,7 @@ var PlaylistExporter = {
             item.added_by == null ? '' : item.added_by.uri,
             item.added_at
           ];
-        });
+        }).filter(e => e);
       });
 
       // Flatten the array of pages

--- a/src/mocks/handlers.jsx
+++ b/src/mocks/handlers.jsx
@@ -427,3 +427,33 @@ export const handlers = [
     ))
   })
 ]
+
+export const nullTrackHandlers = [
+  rest.get('https://api.spotify.com/v1/playlists/4XOGDpHMrVoH33uJEwHWU5/tracks?offset=0&limit=10', (req, res, ctx) => {
+    return res(ctx.json(
+      {
+        "href" : "https://api.spotify.com/v1/playlists/4XOGDpHMrVoH33uJEwHWU5/tracks?offset=0&limit=100",
+        "items" : [
+          {
+            "added_at" : "2020-11-08T22:12:50Z",
+            "added_by" : {
+              "external_urls" : {
+                "spotify" : "https://open.spotify.com/user/"
+              },
+              "href" : "https://api.spotify.com/v1/users/",
+              "id" : "",
+              "type" : "user",
+              "uri" : "spotify:user:"
+            },
+            "is_local" : false,
+            "primary_color" : null,
+            "track" : null,
+            "video_thumbnail" : {
+              "url" : null
+            }
+          }
+        ]
+      }
+    ))
+  })
+]


### PR DESCRIPTION
This should complete the fixes for #48.

Having introduced error tracking, the only issue I see popping up is:

`Cannot read property 'uri' of null` or `t.track is null`.

These are both the same thing and are caused by certain playlists which contain null tracks, for example:

```json
{
  "added_at" : "2020-11-08T22:12:50Z",
  "added_by" : {
    "external_urls" : {
      "spotify" : "https://open.spotify.com/user/"
    },
    "href" : "https://api.spotify.com/v1/users/",
    "id" : "",
    "type" : "user",
    "uri" : "spotify:user:"
  },
  "is_local" : false,
  "primary_color" : null,
  "track" : null,
  "video_thumbnail" : {
    "url" : null
  }
}
```

These simply don't show in the Spotify app, so I've done the same and filtered them out.