### PR TITLE
Add more export data

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,33 @@ Track data is exported in [CSV](http://en.wikipedia.org/wiki/Comma-separated_val
 - Artist Name
 - Album URI
 - Album Name
+- Album Release Date
 - Disc Number
 - Track Number
 - Track Duration (ms)
+- Explicit?
+- Popularity
 - Added By
 - Added At
 
+Additionally, by clicking on the cog and selecting "Include artists data", the following fields will be added:
+
+- Artist Genres
+
+And by selecting "Include audio features data":
+
+- Danceability
+- Energy
+- Key
+- Loudness
+- Mode
+- Speechiness
+- Acousticness
+- Instrumentalness
+- Liveness
+- Valence
+- Tempo
+- Time Signature
 
 ## Development
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -56,7 +56,7 @@ h1 a:hover { color: black; text-decoration: none; }
       text-align: left;
 
       // Transitioning when resetting looks weird
-      &[aria-valuenow="1"] {
+      &[aria-valuenow="0"] {
         transition: none;
       }
     }

--- a/src/App.scss
+++ b/src/App.scss
@@ -45,7 +45,6 @@ h1 a:hover { color: black; text-decoration: none; }
 #playlistsHeader {
   display: flex;
   flex-direction: row-reverse;
-  gap: 20px;
 
   .progress {
     flex-grow: 1;

--- a/src/components/ConfigDropdown.scss
+++ b/src/components/ConfigDropdown.scss
@@ -1,0 +1,38 @@
+.dropdown-toggle::after {
+  display: none;
+}
+
+.dropdown-menu {
+  box-shadow: 1px 1px 4px 0px rgba(0,0,0,0.2);
+}
+
+.dropdown-item {
+  &:active, &:hover {
+    color: black;
+    background: none;
+  }
+
+  label {
+    display: block;
+    cursor: pointer;
+  }
+}
+
+.dropdown {
+  button {
+    padding: 0;
+    margin: 0 20px;
+    height: 31px;
+    color: #dee2e6;
+
+    &:hover {
+      color: silver;
+    }
+  }
+
+  &.show {
+    button {
+      color: #5cb85c;
+    }
+  }
+}

--- a/src/components/ConfigDropdown.tsx
+++ b/src/components/ConfigDropdown.tsx
@@ -1,0 +1,54 @@
+import './ConfigDropdown.scss'
+
+import React from "react"
+import { Dropdown, Form } from "react-bootstrap"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+
+type ConfigDropdownProps = {
+  onConfigChanged: (config: any) => void
+}
+
+class ConfigDropdown extends React.Component<ConfigDropdownProps> {
+  private includeArtistsDataCheck = React.createRef<HTMLInputElement>()
+  private includeAudioFeaturesDataCheck = React.createRef<HTMLInputElement>()
+
+  handleCheckClick = (event: React.MouseEvent) => {
+    event.stopPropagation()
+
+    if ((event.target as HTMLElement).nodeName === "INPUT") {
+      this.props.onConfigChanged({
+        includeArtistsData: this.includeArtistsDataCheck.current?.checked || false,
+        includeAudioFeaturesData: this.includeAudioFeaturesDataCheck.current?.checked || false
+      })
+    }
+  }
+
+  render() {
+    return (
+      <Dropdown>
+        <Dropdown.Toggle variant="link">
+          <FontAwesomeIcon icon={['fas', 'cog']} size="lg" />
+        </Dropdown.Toggle>
+        <Dropdown.Menu align="right">
+          <Dropdown.Item onClickCapture={this.handleCheckClick} as="div">
+            <Form.Check
+              id="config-include-artists-data"
+              type="switch"
+              label="Include artists data"
+              ref={this.includeArtistsDataCheck}
+            />
+          </Dropdown.Item>
+          <Dropdown.Item onClickCapture={this.handleCheckClick} as="div">
+            <Form.Check
+              id="config-include-audio-features-data"
+              type="switch"
+              label="Include audio features data"
+              ref={this.includeAudioFeaturesDataCheck}/>
+          </Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>
+    )
+  }
+}
+
+export default ConfigDropdown

--- a/src/components/PlaylistExporter.tsx
+++ b/src/components/PlaylistExporter.tsx
@@ -2,6 +2,8 @@ import { saveAs } from "file-saver"
 
 import TracksData from "components/tracks_data/TracksData"
 import TracksBaseData from "components/tracks_data/TracksBaseData"
+import TracksArtistsData from "components/tracks_data/TracksArtistsData"
+import TracksAudioFeaturesData from "components/tracks_data/TracksAudioFeaturesData"
 
 class TracksCsvFile {
   playlist: any
@@ -49,10 +51,12 @@ class TracksCsvFile {
 class PlaylistExporter {
   accessToken: string
   playlist: any
+  config: any
 
-  constructor(accessToken: string, playlist: any) {
+  constructor(accessToken: string, playlist: any, config: any) {
     this.accessToken = accessToken
     this.playlist = playlist
+    this.config = config
   }
 
   async export() {
@@ -67,6 +71,17 @@ class PlaylistExporter {
     const tracksBaseData = new TracksBaseData(this.accessToken, this.playlist)
 
     await tracksCsvFile.addData(tracksBaseData)
+    const tracks = await tracksBaseData.tracks()
+
+    if (this.config.includeArtistsData) {
+      const tracksArtistsData = new TracksArtistsData(this.accessToken, tracks)
+      await tracksCsvFile.addData(tracksArtistsData)
+    }
+
+    if (this.config.includeAudioFeaturesData) {
+      const tracksAudioFeaturesData = new TracksAudioFeaturesData(this.accessToken, tracks)
+      await tracksCsvFile.addData(tracksAudioFeaturesData)
+    }
 
     tracksBaseData.tracks()
 

--- a/src/components/PlaylistRow.jsx
+++ b/src/components/PlaylistRow.jsx
@@ -7,7 +7,11 @@ import PlaylistExporter from "./PlaylistExporter"
 
 class PlaylistRow extends React.Component {
   exportPlaylist = () => {
-    (new PlaylistExporter(this.props.accessToken, this.props.playlist)).export().catch(apiCallErrorHandler)
+    (new PlaylistExporter(
+      this.props.accessToken,
+      this.props.playlist,
+      this.props.config
+    )).export().catch(apiCallErrorHandler)
   }
 
   renderTickCross(condition) {

--- a/src/components/PlaylistTable.jsx
+++ b/src/components/PlaylistTable.jsx
@@ -28,6 +28,14 @@ class PlaylistTable extends React.Component {
     }
   }
 
+  constructor(props) {
+    super(props)
+
+    if (props.config) {
+      this.state.config = props.config
+    }
+  }
+
   loadPlaylists = (url) => {
     var userId = '';
     var firstPage = typeof url === 'undefined' || url.indexOf('offset=0') > -1;
@@ -154,13 +162,19 @@ class PlaylistTable extends React.Component {
                     onExportedPlaylistsCountChanged={this.handleExportedPlaylistsCountChanged}
                     playlistCount={this.state.playlistCount}
                     likedSongs={this.state.likedSongs}
+                    config={this.state.config}
                   />
                 </th>
               </tr>
             </thead>
             <tbody>
               {this.state.playlists.map((playlist, i) => {
-                return <PlaylistRow playlist={playlist} key={playlist.id} accessToken={this.props.accessToken}/>
+                return <PlaylistRow
+                  playlist={playlist}
+                  key={playlist.id}
+                  accessToken={this.props.accessToken}
+                  config={this.state.config}
+                />
               })}
             </tbody>
           </table>

--- a/src/components/PlaylistTable.jsx
+++ b/src/components/PlaylistTable.jsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { ProgressBar } from "react-bootstrap"
 
+import ConfigDropdown from "./ConfigDropdown"
 import PlaylistRow from "./PlaylistRow"
 import Paginator from "./Paginator"
 import PlaylistsExporter from "./PlaylistsExporter"
@@ -20,6 +21,10 @@ class PlaylistTable extends React.Component {
       show: false,
       label: "",
       value: 0
+    },
+    config: {
+      includeArtistsData: false,
+      includeAudioFeaturesData: false
     }
   }
 
@@ -114,6 +119,10 @@ class PlaylistTable extends React.Component {
     })
   }
 
+  handleConfigChanged = (config) => {
+    this.setState({ config: config })
+  }
+
   componentDidMount() {
     this.loadPlaylists(this.props.url);
   }
@@ -126,6 +135,7 @@ class PlaylistTable extends React.Component {
         <div id="playlists">
           <div id="playlistsHeader">
             <Paginator nextURL={this.state.nextURL} prevURL={this.state.prevURL} loadPlaylists={this.loadPlaylists}/>
+            <ConfigDropdown onConfigChanged={this.handleConfigChanged} />
             {this.state.progressBar.show && progressBar}
           </div>
           <table className="table table-hover table-sm">

--- a/src/components/PlaylistTable.test.jsx
+++ b/src/components/PlaylistTable.test.jsx
@@ -75,7 +75,6 @@ describe("single playlist exporting", () => {
     fireEvent.click(linkElement)
 
     await waitFor(() => {
-      expect(handlerCalled).toHaveBeenCalledTimes(4)
       expect(handlerCalled.mock.calls).toEqual([ // Ensure API call order and no duplicates
         [ 'https://api.spotify.com/v1/me' ],
         [ 'https://api.spotify.com/v1/users/watsonbox/playlists' ],
@@ -87,8 +86,88 @@ describe("single playlist exporting", () => {
       expect(saveAsMock).toHaveBeenCalledWith(
         {
           content: [
-            '"Track URI","Track Name","Artist URI","Artist Name","Album URI","Album Name","Disc Number","Track Number","Track Duration (ms)","Added By","Added At"\n' +
-            '"spotify:track:1GrLfs4TEvAZ86HVzXHchS","Crying","spotify:artist:4TXdHyuAOl3rAOFmZ6MeKz","Six by Seven","spotify:album:4iwv7b8gDPKztLkKCbWyhi","Best of Six By Seven","1","3","198093","","2020-07-19T09:24:39Z"\n'
+            '"Track URI","Track Name","Artist URI","Artist Name","Album URI","Album Name","Album Release Date","Disc Number","Track Number","Track Duration (ms)","Explicit","Popularity","Added By","Added At"\n' +
+            '"spotify:track:1GrLfs4TEvAZ86HVzXHchS","Crying","spotify:artist:4TXdHyuAOl3rAOFmZ6MeKz","Six by Seven","spotify:album:4iwv7b8gDPKztLkKCbWyhi","Best of Six By Seven","2017-02-17","1","3","198093","false","2","","2020-07-19T09:24:39Z"\n'
+          ],
+          options: { type: 'text/csv;charset=utf-8' }
+        },
+        'liked.csv',
+        true
+      )
+    })
+  })
+
+  test("including additional artist data", async () => {
+    const saveAsMock = jest.spyOn(FileSaver, "saveAs")
+    saveAsMock.mockImplementation(jest.fn())
+
+    render(<PlaylistTable accessToken="TEST_ACCESS_TOKEN" config={{ includeArtistsData: true }} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Export All/)).toBeInTheDocument()
+    })
+
+    const linkElement = screen.getAllByText("Export")[0]
+
+    expect(linkElement).toBeInTheDocument()
+
+    fireEvent.click(linkElement)
+
+    await waitFor(() => {
+      expect(handlerCalled.mock.calls).toEqual([ // Ensure API call order and no duplicates
+        [ 'https://api.spotify.com/v1/me' ],
+        [ 'https://api.spotify.com/v1/users/watsonbox/playlists' ],
+        [ 'https://api.spotify.com/v1/users/watsonbox/tracks' ],
+        [ 'https://api.spotify.com/v1/me/tracks?offset=0&limit=20' ],
+        [ 'https://api.spotify.com/v1/artists?ids=4TXdHyuAOl3rAOFmZ6MeKz' ]
+      ])
+
+      expect(saveAsMock).toHaveBeenCalledTimes(1)
+      expect(saveAsMock).toHaveBeenCalledWith(
+        {
+          content: [
+            '"Track URI","Track Name","Artist URI","Artist Name","Album URI","Album Name","Album Release Date","Disc Number","Track Number","Track Duration (ms)","Explicit","Popularity","Added By","Added At","Artist Genres"\n' +
+            '"spotify:track:1GrLfs4TEvAZ86HVzXHchS","Crying","spotify:artist:4TXdHyuAOl3rAOFmZ6MeKz","Six by Seven","spotify:album:4iwv7b8gDPKztLkKCbWyhi","Best of Six By Seven","2017-02-17","1","3","198093","false","2","","2020-07-19T09:24:39Z","nottingham indie"\n'
+          ],
+          options: { type: 'text/csv;charset=utf-8' }
+        },
+        'liked.csv',
+        true
+      )
+    })
+  })
+
+  test("including additional audio features data", async () => {
+    const saveAsMock = jest.spyOn(FileSaver, "saveAs")
+    saveAsMock.mockImplementation(jest.fn())
+
+    render(<PlaylistTable accessToken="TEST_ACCESS_TOKEN" config={{ includeAudioFeaturesData: true }} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Export All/)).toBeInTheDocument()
+    })
+
+    const linkElement = screen.getAllByText("Export")[0]
+
+    expect(linkElement).toBeInTheDocument()
+
+    fireEvent.click(linkElement)
+
+    await waitFor(() => {
+      expect(handlerCalled.mock.calls).toEqual([ // Ensure API call order and no duplicates
+        [ 'https://api.spotify.com/v1/me' ],
+        [ 'https://api.spotify.com/v1/users/watsonbox/playlists' ],
+        [ 'https://api.spotify.com/v1/users/watsonbox/tracks' ],
+        [ 'https://api.spotify.com/v1/me/tracks?offset=0&limit=20' ],
+        [ 'https://api.spotify.com/v1/audio-features?ids=1GrLfs4TEvAZ86HVzXHchS' ]
+      ])
+
+      expect(saveAsMock).toHaveBeenCalledTimes(1)
+      expect(saveAsMock).toHaveBeenCalledWith(
+        {
+          content: [
+            '"Track URI","Track Name","Artist URI","Artist Name","Album URI","Album Name","Album Release Date","Disc Number","Track Number","Track Duration (ms)","Explicit","Popularity","Added By","Added At","Danceability","Energy","Key","Loudness","Mode","Speechiness","Acousticness","Instrumentalness","Liveness","Valence","Tempo","Time Signature"\n' +
+            '"spotify:track:1GrLfs4TEvAZ86HVzXHchS","Crying","spotify:artist:4TXdHyuAOl3rAOFmZ6MeKz","Six by Seven","spotify:album:4iwv7b8gDPKztLkKCbWyhi","Best of Six By Seven","2017-02-17","1","3","198093","false","2","","2020-07-19T09:24:39Z","0.416","0.971","0","-5.55","1","0.0575","0.00104","0.0391","0.44","0.19","131.988","4"\n'
           ],
           options: { type: 'text/csv;charset=utf-8' }
         },
@@ -121,7 +200,7 @@ describe("single playlist exporting", () => {
       expect(saveAsMock).toHaveBeenCalledWith(
         {
           content: [
-            '"Track URI","Track Name","Artist URI","Artist Name","Album URI","Album Name","Disc Number","Track Number","Track Duration (ms)","Added By","Added At"\n'
+            '"Track URI","Track Name","Artist URI","Artist Name","Album URI","Album Name","Album Release Date","Disc Number","Track Number","Track Duration (ms)","Explicit","Popularity","Added By","Added At"\n'
           ],
           options: { type: 'text/csv;charset=utf-8' }
         },
@@ -156,14 +235,14 @@ test("exporting of all playlists", async () => {
     expect(jsZipFileMock).toHaveBeenCalledTimes(2)
     expect(jsZipFileMock).toHaveBeenCalledWith(
       "liked.csv",
-      '"Track URI","Track Name","Artist URI","Artist Name","Album URI","Album Name","Disc Number","Track Number","Track Duration (ms)","Added By","Added At"\n' +
-      '"spotify:track:1GrLfs4TEvAZ86HVzXHchS","Crying","spotify:artist:4TXdHyuAOl3rAOFmZ6MeKz","Six by Seven","spotify:album:4iwv7b8gDPKztLkKCbWyhi","Best of Six By Seven","1","3","198093","","2020-07-19T09:24:39Z"\n'
+      '"Track URI","Track Name","Artist URI","Artist Name","Album URI","Album Name","Album Release Date","Disc Number","Track Number","Track Duration (ms)","Explicit","Popularity","Added By","Added At"\n' +
+      '"spotify:track:1GrLfs4TEvAZ86HVzXHchS","Crying","spotify:artist:4TXdHyuAOl3rAOFmZ6MeKz","Six by Seven","spotify:album:4iwv7b8gDPKztLkKCbWyhi","Best of Six By Seven","2017-02-17","1","3","198093","false","2","","2020-07-19T09:24:39Z"\n'
     )
     expect(jsZipFileMock).toHaveBeenCalledWith(
       "ghostpoet_–_peanut_butter_blues_and_melancholy_jam.csv",
-      '"Track URI","Track Name","Artist URI","Artist Name","Album URI","Album Name","Disc Number","Track Number","Track Duration (ms)","Added By","Added At"\n' +
-      '"spotify:track:7ATyvp3TmYBmGW7YuC8DJ3","One Twos / Run Run Run","spotify:artist:69lEbRQRe29JdyLrewNAvD","Ghostpoet","spotify:album:6jiLkuSnhzDvzsHJlweoGh","Peanut Butter Blues and Melancholy Jam","1","1","241346","spotify:user:watsonbox","2020-11-03T15:19:04Z"\n' +
-      '"spotify:track:0FNanBLvmFEDyD75Whjj52","Us Against Whatever Ever","spotify:artist:69lEbRQRe29JdyLrewNAvD","Ghostpoet","spotify:album:6jiLkuSnhzDvzsHJlweoGh","Peanut Butter Blues and Melancholy Jam","1","2","269346","spotify:user:watsonbox","2020-11-03T15:19:04Z"\n'
+      '"Track URI","Track Name","Artist URI","Artist Name","Album URI","Album Name","Album Release Date","Disc Number","Track Number","Track Duration (ms)","Explicit","Popularity","Added By","Added At"\n' +
+      '"spotify:track:7ATyvp3TmYBmGW7YuC8DJ3","One Twos / Run Run Run","spotify:artist:69lEbRQRe29JdyLrewNAvD","Ghostpoet","spotify:album:6jiLkuSnhzDvzsHJlweoGh","Peanut Butter Blues and Melancholy Jam","2011","1","1","241346","false","22","spotify:user:watsonbox","2020-11-03T15:19:04Z"\n' +
+      '"spotify:track:0FNanBLvmFEDyD75Whjj52","Us Against Whatever Ever","spotify:artist:69lEbRQRe29JdyLrewNAvD","Ghostpoet","spotify:album:6jiLkuSnhzDvzsHJlweoGh","Peanut Butter Blues and Melancholy Jam","2011","1","2","269346","false","36","spotify:user:watsonbox","2020-11-03T15:19:04Z"\n'
     )
   })
 

--- a/src/components/PlaylistsExporter.jsx
+++ b/src/components/PlaylistsExporter.jsx
@@ -9,7 +9,7 @@ import { apiCall, apiCallErrorHandler } from "helpers"
 
 // Handles exporting all playlist data as a zip file
 class PlaylistsExporter extends React.Component {
-  async export(accessToken, playlistCount, likedSongsLimit, likedSongsCount) {
+  async export(accessToken, playlistCount, likedSongsLimit, likedSongsCount, config) {
     var playlistFileNames = []
     var playlistCsvExports = []
 
@@ -47,7 +47,7 @@ class PlaylistsExporter extends React.Component {
       let index = 0
 
       for (const playlist of playlists) {
-        let exporter = new PlaylistExporter(accessToken, playlist)
+        let exporter = new PlaylistExporter(accessToken, playlist, config)
         let csvData = await exporter.csvData()
 
         playlistFileNames.push(exporter.fileName(playlist))
@@ -69,7 +69,13 @@ class PlaylistsExporter extends React.Component {
   }
 
   exportPlaylists = () => {
-    this.export(this.props.accessToken, this.props.playlistCount, this.props.likedSongs.limit, this.props.likedSongs.count)
+    this.export(
+      this.props.accessToken,
+      this.props.playlistCount,
+      this.props.likedSongs.limit,
+      this.props.likedSongs.count,
+      this.props.config
+    )
   }
 
   render() {

--- a/src/components/__snapshots__/PlaylistTable.test.jsx.snap
+++ b/src/components/__snapshots__/PlaylistTable.test.jsx.snap
@@ -47,6 +47,37 @@ exports[`playlist loading 1`] = `
         </li>
       </ul>
     </nav>
+    <div
+      className="dropdown"
+      onKeyDown={[Function]}
+    >
+      <button
+        aria-expanded={false}
+        aria-haspopup={true}
+        className="dropdown-toggle btn btn-link"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-cog fa-w-16 fa-lg "
+          data-icon="cog"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M487.4 315.7l-42.6-24.6c4.3-23.2 4.3-47 0-70.2l42.6-24.6c4.9-2.8 7.1-8.6 5.5-14-11.1-35.6-30-67.8-54.7-94.6-3.8-4.1-10-5.1-14.8-2.3L380.8 110c-17.9-15.4-38.5-27.3-60.8-35.1V25.8c0-5.6-3.9-10.5-9.4-11.7-36.7-8.2-74.3-7.8-109.2 0-5.5 1.2-9.4 6.1-9.4 11.7V75c-22.2 7.9-42.8 19.8-60.8 35.1L88.7 85.5c-4.9-2.8-11-1.9-14.8 2.3-24.7 26.7-43.6 58.9-54.7 94.6-1.7 5.4.6 11.2 5.5 14L67.3 221c-4.3 23.2-4.3 47 0 70.2l-42.6 24.6c-4.9 2.8-7.1 8.6-5.5 14 11.1 35.6 30 67.8 54.7 94.6 3.8 4.1 10 5.1 14.8 2.3l42.6-24.6c17.9 15.4 38.5 27.3 60.8 35.1v49.2c0 5.6 3.9 10.5 9.4 11.7 36.7 8.2 74.3 7.8 109.2 0 5.5-1.2 9.4-6.1 9.4-11.7v-49.2c22.2-7.9 42.8-19.8 60.8-35.1l42.6 24.6c4.9 2.8 11 1.9 14.8-2.3 24.7-26.7 43.6-58.9 54.7-94.6 1.5-5.5-.7-11.3-5.6-14.1zM256 336c-44.1 0-80-35.9-80-80s35.9-80 80-80 80 35.9 80 80-35.9 80-80 80z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+      </button>
+    </div>
   </div>
   <table
     className="table table-hover table-sm"

--- a/src/components/tracks_data/TracksArtistsData.tsx
+++ b/src/components/tracks_data/TracksArtistsData.tsx
@@ -1,0 +1,53 @@
+import TracksData from "./TracksData"
+import { apiCall } from "helpers"
+
+class TracksArtistsData extends TracksData {
+  ARTIST_LIMIT = 50
+
+  tracks: any[]
+
+  constructor(accessToken: string, tracks: any[]) {
+    super(accessToken)
+    this.tracks = tracks
+  }
+
+  dataLabels() {
+    return [
+      "Artist Genres"
+    ]
+  }
+
+  async data() {
+    const artistIds = Array.from(new Set(this.tracks.flatMap((track: any) => {
+      return track
+        .artists
+        .filter((a: any) => a.type === "artist")
+        .map((a: any) => a.id)
+        .filter((i: string) => i)
+    })))
+
+    let requests = []
+
+    for (var offset = 0; offset < artistIds.length; offset = offset + this.ARTIST_LIMIT) {
+      requests.push(`https://api.spotify.com/v1/artists?ids=${artistIds.slice(offset, offset + this.ARTIST_LIMIT)}`)
+    }
+
+    const artistPromises = requests.map(request => { return apiCall(request, this.accessToken) })
+    const artistResponses = await Promise.all(artistPromises)
+
+    const artistsById = new Map(artistResponses.flatMap((response) => response.data.artists).map((artist: any) => [artist.id, artist]))
+
+    return new Map<string, string[]>(this.tracks.map((track: any) => {
+      return [
+        track.id,
+        [
+          track.artists.map((a: any) => {
+            return artistsById.has(a.id) ? artistsById.get(a.id)!.genres.filter((g: string) => g).join(',') : ""
+          }).filter((g: string) => g).join(",")
+        ]
+      ]
+    }))
+  }
+}
+
+export default TracksArtistsData

--- a/src/components/tracks_data/TracksAudioFeaturesData.tsx
+++ b/src/components/tracks_data/TracksAudioFeaturesData.tsx
@@ -1,0 +1,73 @@
+import TracksData from "./TracksData"
+import { apiCall } from "helpers"
+
+class TracksAudioFeaturesData extends TracksData {
+  AUDIO_FEATURES_LIMIT = 100
+
+  tracks: any[]
+
+  constructor(accessToken: string, tracks: any[]) {
+    super(accessToken)
+    this.tracks = tracks
+  }
+
+  dataLabels() {
+    return [
+      "Danceability",
+      "Energy",
+      "Key",
+      "Loudness",
+      "Mode",
+      "Speechiness",
+      "Acousticness",
+      "Instrumentalness",
+      "Liveness",
+      "Valence",
+      "Tempo",
+      "Time Signature"
+    ]
+  }
+
+  async data() {
+    const trackIds = this.tracks.map((track: any) => track.id)
+
+    let requests = []
+
+    for (var offset = 0; offset < trackIds.length; offset = offset + this.AUDIO_FEATURES_LIMIT) {
+      requests.push(`https://api.spotify.com/v1/audio-features?ids=${trackIds.slice(offset, offset + this.AUDIO_FEATURES_LIMIT)}`)
+    }
+
+    const audioFeaturesPromises = requests.map(request => { return apiCall(request, this.accessToken) })
+    const audioFeatures = (await Promise.all(audioFeaturesPromises)).flatMap((response) => response.data.audio_features)
+
+    const audioFeaturesData = new Map<string, string[]>(audioFeatures.filter((af: any) => af).map((audioFeatures: any) => {
+      return [
+        audioFeatures.id,
+        [
+          audioFeatures.danceability,
+          audioFeatures.energy,
+          audioFeatures.key,
+          audioFeatures.loudness,
+          audioFeatures.mode,
+          audioFeatures.speechiness,
+          audioFeatures.acousticness,
+          audioFeatures.instrumentalness,
+          audioFeatures.liveness,
+          audioFeatures.valence,
+          audioFeatures.tempo,
+          audioFeatures.time_signature
+        ]
+      ]
+    }))
+
+    // Add empty fields where we didn't get data - can be the case for example with episodes
+    const audioFeaturesTrackIds = Array.from(audioFeaturesData.keys())
+    trackIds.filter(x => !audioFeaturesTrackIds.includes(x)).forEach((trackId) => {
+      audioFeaturesData.set(trackId, ["","","","","","","","","","","",""])
+    })
+
+    return audioFeaturesData
+  }
+}
+
+export default TracksAudioFeaturesData

--- a/src/components/tracks_data/TracksBaseData.tsx
+++ b/src/components/tracks_data/TracksBaseData.tsx
@@ -17,9 +17,12 @@ class TracksBaseData extends TracksData {
       "Artist Name",
       "Album URI",
       "Album Name",
+      "Album Release Date",
       "Disc Number",
       "Track Number",
       "Track Duration (ms)",
+      "Explicit",
+      "Popularity",
       "Added By",
       "Added At"
     ]
@@ -44,9 +47,12 @@ class TracksBaseData extends TracksData {
           item.track.artists.map((a: any) => { return String(a.name).replace(/,/g, "\\,") }).join(', '),
           item.track.album.uri,
           item.track.album.name,
+          item.track.album.release_date,
           item.track.disc_number,
           item.track.track_number,
           item.track.duration_ms,
+          item.track.explicit,
+          item.track.popularity,
           item.added_by == null ? '' : item.added_by.uri,
           item.added_at
         ]

--- a/src/icons.jsx
+++ b/src/icons.jsx
@@ -1,6 +1,6 @@
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { fab } from '@fortawesome/free-brands-svg-icons'
 import { faCheckCircle, faTimesCircle, faFileArchive, faHeart } from '@fortawesome/free-regular-svg-icons'
-import { faBolt, faMusic, faDownload } from '@fortawesome/free-solid-svg-icons'
+import { faBolt, faMusic, faDownload, faCog } from '@fortawesome/free-solid-svg-icons'
 
-library.add(fab, faCheckCircle, faTimesCircle, faFileArchive, faHeart, faBolt, faMusic, faDownload)
+library.add(fab, faCheckCircle, faTimesCircle, faFileArchive, faHeart, faBolt, faMusic, faDownload, faCog)

--- a/src/mocks/handlers.jsx
+++ b/src/mocks/handlers.jsx
@@ -457,6 +457,81 @@ export const handlers = [
         "total" : 2
       }
     ))
+  }),
+
+  rest.get('https://api.spotify.com/v1/artists?ids=4TXdHyuAOl3rAOFmZ6MeKz', (req, res, ctx) => {
+    handlerCalled(req.url.toString())
+
+    if (req.headers.get("Authorization") !== "Bearer TEST_ACCESS_TOKEN") {
+      return res(ctx.status(401), ctx.json({ message: 'Not authorized' }))
+    }
+
+    return res(ctx.json(
+      {
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/4TXdHyuAOl3rAOFmZ6MeKz"
+          },
+          "followers" : {
+            "href" : null,
+            "total" : 2541
+          },
+          "genres" : [ "nottingham indie" ],
+          "href" : "https://api.spotify.com/v1/artists/4TXdHyuAOl3rAOFmZ6MeKz",
+          "id" : "4TXdHyuAOl3rAOFmZ6MeKz",
+          "images" : [ {
+            "height" : 640,
+            "url" : "https://i.scdn.co/image/ab67616d0000b273244214fb6bf581d5c7595c6d",
+            "width" : 640
+          }, {
+            "height" : 300,
+            "url" : "https://i.scdn.co/image/ab67616d00001e02244214fb6bf581d5c7595c6d",
+            "width" : 300
+          }, {
+            "height" : 64,
+            "url" : "https://i.scdn.co/image/ab67616d00004851244214fb6bf581d5c7595c6d",
+            "width" : 64
+          } ],
+          "name" : "Six by Seven",
+          "popularity" : 17,
+          "type" : "artist",
+          "uri" : "spotify:artist:4TXdHyuAOl3rAOFmZ6MeKz"
+        } ]
+      }
+    ))
+  }),
+
+  rest.get('https://api.spotify.com/v1/audio-features?ids=1GrLfs4TEvAZ86HVzXHchS', (req, res, ctx) => {
+    handlerCalled(req.url.toString())
+
+    if (req.headers.get("Authorization") !== "Bearer TEST_ACCESS_TOKEN") {
+      return res(ctx.status(401), ctx.json({ message: 'Not authorized' }))
+    }
+
+    return res(ctx.json(
+      {
+        "audio_features" : [ {
+          "danceability" : 0.416,
+          "energy" : 0.971,
+          "key" : 0,
+          "loudness" : -5.550,
+          "mode" : 1,
+          "speechiness" : 0.0575,
+          "acousticness" : 0.00104,
+          "instrumentalness" : 0.0391,
+          "liveness" : 0.440,
+          "valence" : 0.190,
+          "tempo" : 131.988,
+          "type" : "audio_features",
+          "id" : "1GrLfs4TEvAZ86HVzXHchS",
+          "uri" : "spotify:track:1GrLfs4TEvAZ86HVzXHchS",
+          "track_href" : "https://api.spotify.com/v1/tracks/1GrLfs4TEvAZ86HVzXHchS",
+          "analysis_url" : "https://api.spotify.com/v1/audio-analysis/1GrLfs4TEvAZ86HVzXHchS",
+          "duration_ms" : 198093,
+          "time_signature" : 4
+        } ]
+      }
+    ))
   })
 ]
 


### PR DESCRIPTION
See #67.

This PR introduces the additional data requested in #67 as well as that included in #70. I've marked that specific commit as co-authored since I drew inspiration from that code, though wasn't able to merge it as-is. @pavel-aicradle let me know if that's okay for you 🙂 .

This PR also introduces a lightweight configuration interface so that we don't include data requiring many extra requests by default. This should keep any unnecessary API calls to a minimum, while leaving the option there for more advanced users. It looks like this:

![Screen Shot 2020-11-20 at 22 58 36](https://user-images.githubusercontent.com/17737/99854105-7bf0fb00-2b84-11eb-82ab-9ff07e76b267.png)