### PR TITLE
Add playlist searching

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -46,6 +46,10 @@ h1 a:hover { color: black; text-decoration: none; }
   display: flex;
   flex-direction: row-reverse;
 
+  .paginator {
+    margin-left: 20px;
+  }
+
   .progress {
     flex-grow: 1;
     height: 30px;
@@ -60,6 +64,10 @@ h1 a:hover { color: black; text-decoration: none; }
         transition: none;
       }
     }
+  }
+
+  form {
+    margin-left: 20px;
   }
 }
 

--- a/src/components/ConfigDropdown.scss
+++ b/src/components/ConfigDropdown.scss
@@ -19,9 +19,10 @@
 }
 
 .dropdown {
+  margin-left: 20px;
+
   button {
     padding: 0;
-    margin: 0 20px;
     height: 31px;
     color: #dee2e6;
 

--- a/src/components/PlaylistSearch.scss
+++ b/src/components/PlaylistSearch.scss
@@ -1,0 +1,29 @@
+#playlistsHeader {
+  form.search {
+    input {
+      width: 64px;
+      transition: width 250ms ease-in-out;
+      border-color: #dee2e6;
+
+      &:focus {
+        width: 200px;
+      }
+    }
+
+    &.queryPresent {
+      input {
+        width: 200px;
+      }
+    }
+
+    .input-group-append .input-group-text {
+      color: #dee2e6;
+      border-color: #dee2e6;
+      padding-left: 0;
+    }
+
+    .closeIcon, .searchIcon {
+      cursor: pointer;
+    }
+  }
+}

--- a/src/components/PlaylistSearch.tsx
+++ b/src/components/PlaylistSearch.tsx
@@ -1,0 +1,88 @@
+import './PlaylistSearch.scss'
+
+import React from "react"
+import { Form, InputGroup } from "react-bootstrap"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+
+type PlaylistSearchProps = {
+  onPlaylistSearch: (query: string) => void
+  onPlaylistSearchCancel: () => Promise<any>
+}
+
+class PlaylistSearch extends React.Component<PlaylistSearchProps> {
+  private searchField = React.createRef<HTMLInputElement>()
+
+  state = {
+    searchSubmitted: false,
+    query: ""
+  }
+
+  clear() {
+    this.setState(
+      { searchSubmitted: false, query: "" },
+      () => {
+        if (this.searchField.current) {
+          this.searchField.current.value = ""
+        }
+      }
+    )
+  }
+
+  handleKeyDown = (event: React.KeyboardEvent) => {
+    event.stopPropagation()
+
+    if (event.key === 'Enter') {
+      this.submitSearch()
+
+      event.preventDefault()
+    } else if (event.key === 'Escape') {
+      this.cancelSearch()
+    }
+  }
+
+  handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ query: event.target.value })
+  }
+
+  private submitSearch = () => {
+    if (this.state.query.length > 0) {
+      this.setState(
+        { searchSubmitted: true },
+        () => { this.props.onPlaylistSearch(this.state.query) }
+      )
+    }
+  }
+
+  private cancelSearch = () => {
+    this.props.onPlaylistSearchCancel().then(() => {
+      this.clear()
+
+      if (this.searchField.current) {
+        this.searchField.current.blur()
+      }
+    })
+  }
+
+  render() {
+    const icon = (this.state.searchSubmitted)
+      ? <FontAwesomeIcon icon={['fas', 'times']} size="sm" onClick={this.cancelSearch} className="closeIcon" />
+      : <FontAwesomeIcon icon={['fas', 'search']} size="sm" onClick={this.submitSearch} className="searchIcon" />
+
+    const className = this.state.query.length > 0 ? "search queryPresent" : "search"
+
+    return (
+      <Form className={className}>
+        <InputGroup>
+          <Form.Control type="text" role="searchbox" placeholder="Search" size="sm" onChange={this.handleChange} onKeyDown={this.handleKeyDown} ref={this.searchField} className="border-right-0 border" />
+          <InputGroup.Append>
+            <InputGroup.Text className="bg-transparent">
+              {icon}
+            </InputGroup.Text>
+          </InputGroup.Append>
+        </InputGroup>
+      </Form>
+    )
+  }
+}
+
+export default PlaylistSearch

--- a/src/components/PlaylistTable.jsx
+++ b/src/components/PlaylistTable.jsx
@@ -3,6 +3,7 @@ import { ProgressBar } from "react-bootstrap"
 
 import PlaylistsData from "./data/PlaylistsData"
 import ConfigDropdown from "./ConfigDropdown"
+import PlaylistSearch from "./PlaylistSearch"
 import PlaylistRow from "./PlaylistRow"
 import Paginator from "./Paginator"
 import PlaylistsExporter from "./PlaylistsExporter"
@@ -15,6 +16,8 @@ class PlaylistTable extends React.Component {
   playlistsData = null
 
   state = {
+    initialized: false,
+    searching: false,
     playlists: [],
     playlistCount: 0,
     likedSongs: {
@@ -37,12 +40,43 @@ class PlaylistTable extends React.Component {
     super(props)
 
     this.configDropdown = React.createRef()
+    this.playlistSearch = React.createRef()
+
     if (props.config) {
       this.state.config = props.config
     }
   }
 
+  handlePlaylistSearch = async (query) => {
+    if (query.length === 0) {
+      this.handlePlaylistSearchCancel()
+    } else {
+      const playlists = await this.playlistsData.search(query).catch(apiCallErrorHandler)
+
+      this.setState({
+        searching: true,
+        playlists: playlists,
+        playlistCount: playlists.length,
+        currentPage: 1
+      })
+
+      if (playlists.length === this.playlistsData.SEARCH_LIMIT) {
+        this.setSubtitle(`First ${playlists.length} results with "${query}" in playlist name`)
+      } else {
+        this.setSubtitle(`${playlists.length} results with "${query}" in playlist name`)
+      }
+    }
+  }
+
+  handlePlaylistSearchCancel = () => {
+    return this.loadCurrentPlaylistPage().catch(apiCallErrorHandler)
+  }
+
   loadCurrentPlaylistPage = async () => {
+    if (this.playlistSearch.current) {
+      this.playlistSearch.current.clear()
+    }
+
     const playlists = await this.playlistsData.slice(
       ((this.state.currentPage - 1) * this.PAGE_SIZE),
       ((this.state.currentPage - 1) * this.PAGE_SIZE) + this.PAGE_SIZE
@@ -84,6 +118,8 @@ class PlaylistTable extends React.Component {
     // FIXME: Handle unmounting
     this.setState(
       {
+        initialized: true,
+        searching: false,
         playlists: playlists,
         playlistCount: await this.playlistsData.total()
       },
@@ -164,11 +200,12 @@ class PlaylistTable extends React.Component {
   render() {
     const progressBar = <ProgressBar striped variant="primary" animated={this.state.progressBar.value < this.state.playlistCount} now={this.state.progressBar.value} max={this.state.playlistCount} label={this.state.progressBar.label} />
 
-    if (this.state.playlistCount > 0) {
+    if (this.state.initialized) {
       return (
         <div id="playlists">
           <div id="playlistsHeader">
             <Paginator currentPage={this.state.currentPage} pageLimit={this.PAGE_SIZE} totalRecords={this.state.playlistCount} onPageChanged={this.handlePageChanged}/>
+            <PlaylistSearch onPlaylistSearch={this.handlePlaylistSearch} onPlaylistSearchCancel={this.handlePlaylistSearchCancel} ref={this.playlistSearch} />
             <ConfigDropdown onConfigChanged={this.handleConfigChanged} ref={this.configDropdown} />
             {this.state.progressBar.show && progressBar}
           </div>
@@ -189,6 +226,7 @@ class PlaylistTable extends React.Component {
                     playlistsData={this.playlistsData}
                     likedSongs={this.state.likedSongs}
                     config={this.state.config}
+                    disabled={this.state.searching}
                   />
                 </th>
               </tr>

--- a/src/components/PlaylistTable.test.jsx
+++ b/src/components/PlaylistTable.test.jsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { render, screen, waitFor, fireEvent } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import renderer from "react-test-renderer"
 import { setupServer } from "msw/node"
 import FileSaver from "file-saver"
@@ -207,6 +208,48 @@ describe("single playlist exporting", () => {
         'ghostpoet_–_peanut_butter_blues_and_melancholy_jam.csv',
         true
       )
+    })
+  })
+})
+
+describe("searching playlists", () => {
+  test("simple successful search", async () => {
+    render(<PlaylistTable accessToken="TEST_ACCESS_TOKEN" />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('searchbox')).toBeInTheDocument()
+    })
+
+    userEvent.type(screen.getByRole('searchbox'), 'Ghost{enter}')
+
+    await waitFor(() => {
+      // Liked tracks is gone but Ghostpoet still matches
+      expect(screen.queryByText("Liked")).not.toBeInTheDocument()
+      expect(screen.queryByText("Ghostpoet – Peanut Butter Blues and Melancholy Jam")).toBeInTheDocument()
+    })
+
+    userEvent.type(screen.getByRole('searchbox'), '{esc}')
+
+    await waitFor(() => {
+      // Both liked tracks and Ghostpoet are present
+      expect(screen.queryByText("Liked")).toBeInTheDocument()
+      expect(screen.queryByText("Ghostpoet – Peanut Butter Blues and Melancholy Jam")).toBeInTheDocument()
+    })
+  })
+
+  test("search with no results", async () => {
+    render(<PlaylistTable accessToken="TEST_ACCESS_TOKEN" />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('searchbox')).toBeInTheDocument()
+    })
+
+    userEvent.type(screen.getByRole('searchbox'), 'test{enter}')
+
+    await waitFor(() => {
+      // Both liked tracks and Ghostpoet are missing
+      expect(screen.queryByText("Liked")).not.toBeInTheDocument()
+      expect(screen.queryByText("Ghostpoet – Peanut Butter Blues and Melancholy Jam")).not.toBeInTheDocument()
     })
   })
 })

--- a/src/components/PlaylistsExporter.jsx
+++ b/src/components/PlaylistsExporter.jsx
@@ -64,7 +64,7 @@ class PlaylistsExporter extends React.Component {
   }
 
   render() {
-    return <Button type="submit" variant="outline-secondary" size="xs" onClick={this.exportPlaylists} className="text-nowrap">
+    return <Button type="submit" variant="outline-secondary" size="xs" onClick={this.exportPlaylists} className="text-nowrap" disabled={this.props.disabled}>
       <FontAwesomeIcon icon={['far', 'file-archive']}/> Export All
     </Button>
   }

--- a/src/components/__snapshots__/PlaylistTable.test.jsx.snap
+++ b/src/components/__snapshots__/PlaylistTable.test.jsx.snap
@@ -47,6 +47,48 @@ exports[`playlist loading 1`] = `
         </li>
       </ul>
     </nav>
+    <form
+      className="search"
+    >
+      <div
+        className="input-group"
+      >
+        <input
+          className="border-right-0 border form-control form-control-sm"
+          onChange={[Function]}
+          onKeyDown={[Function]}
+          placeholder="Search"
+          role="searchbox"
+          type="text"
+        />
+        <div
+          className="input-group-append"
+        >
+          <span
+            className="bg-transparent input-group-text"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-search fa-w-16 fa-sm searchIcon"
+              data-icon="search"
+              data-prefix="fas"
+              focusable="false"
+              onClick={[Function]}
+              role="img"
+              style={Object {}}
+              viewBox="0 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+          </span>
+        </div>
+      </div>
+    </form>
     <div
       className="dropdown"
       onKeyDown={[Function]}

--- a/src/components/data/PlaylistsData.tsx
+++ b/src/components/data/PlaylistsData.tsx
@@ -3,6 +3,7 @@ import { apiCall } from "helpers"
 // Handles cached loading of all or subsets of playlist data
 class PlaylistsData {
   PLAYLIST_LIMIT = 50
+  SEARCH_LIMIT = 20
 
   userId: string
   private accessToken: string
@@ -35,6 +36,16 @@ class PlaylistsData {
     await this.loadAll()
 
     return this.data
+  }
+
+  async search(query: string) {
+    await this.loadAll()
+
+    // Case-insensitive search in playlist name
+    // TODO: Add lazy evaluation for performance?
+    return this.data
+      .filter(p => p.name.toLowerCase().includes(query.toLowerCase()))
+      .slice(0, this.SEARCH_LIMIT)
   }
 
   async loadAll() {

--- a/src/icons.jsx
+++ b/src/icons.jsx
@@ -1,6 +1,6 @@
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { fab } from '@fortawesome/free-brands-svg-icons'
 import { faCheckCircle, faTimesCircle, faFileArchive, faHeart } from '@fortawesome/free-regular-svg-icons'
-import { faBolt, faMusic, faDownload, faCog } from '@fortawesome/free-solid-svg-icons'
+import { faBolt, faMusic, faDownload, faCog, faSearch, faTimes } from '@fortawesome/free-solid-svg-icons'
 
-library.add(fab, faCheckCircle, faTimesCircle, faFileArchive, faHeart, faBolt, faMusic, faDownload, faCog)
+library.add(fab, faCheckCircle, faTimesCircle, faFileArchive, faHeart, faBolt, faMusic, faDownload, faCog, faSearch, faTimes)

--- a/src/index.scss
+++ b/src/index.scss
@@ -5,6 +5,7 @@ $table-hover-bg: rgba(#000, .025);
 $btn-transition: none;
 $body-color: #191414;
 $input-btn-focus-box-shadow: none;
+$input-placeholder-color: #dee2e6;
 
 @import "~bootstrap/scss/bootstrap";
 


### PR DESCRIPTION
Implementation of solution for #19 allowing playlists to be searched. Based on refactoring in #81.

![Screen Recording 2020-11-25 at 09 20 05 am](https://user-images.githubusercontent.com/17737/100201109-eb0d7d00-2eff-11eb-993e-7ed955e2361c.gif)

Use the search bar to match playlists with the search string in their name (case insensitive), and return up to 20 results.

I decided to take a search rather than column sorting approach since it seemed to better fit the use cases that have been coming up, and even if you sort on playlist name, it might still be necessary to page a long way to get to the playlist of interest.

I also didn't implement exporting of all the search results. This might be useful for some people but my goal isn't to provide every possible feature, but to make the most common use-cases easier, like using the tool to quickly export a single playlist.

The Export All facility can always be used along with custom post-processing for more advanced purposes.