### PR TITLE
Add the option to include extended album data

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ And by selecting "Include audio features data", the following fields will be add
 - Tempo
 - Time Signature
 
+Additionally, by selecting "Include extended album data", the following fields will be added from the [Spotify album object (full)](https://developer.spotify.com/documentation/web-api/reference/object-model/#album-object-full)
+
+- Album Genres
+- Label
+- Copyrights
+
 Note that the more data being exported, the longer the export will take.
 
 ### Playlist Search
@@ -115,9 +121,9 @@ In addition to [Create React App](https://github.com/facebook/create-react-app),
 ## Notes
 
 - According to Spotify's [documentation](https://developer.spotify.com/web-api/working-with-playlists/):
-  
+
   > Folders are not returned through the Web API at the moment, nor can be created using it".
-  
+
   Unfortunately that's just how it is.
 
 - I've [gone to some lengths](https://github.com/watsonbox/exportify/pull/75) to try to eliminate errors resulting from excessively high usage of the Spotify API. Nonetheless, exporting data in bulk is a fairly request-intensive process, so please do try to use this tool responsibly. If you do require more throughput, please consider [creating your own Spotify application](https://github.com/watsonbox/exportify/issues/6#issuecomment-110793132) which you can use with Exportify directly.

--- a/src/components/ConfigDropdown.tsx
+++ b/src/components/ConfigDropdown.tsx
@@ -11,6 +11,7 @@ type ConfigDropdownProps = {
 class ConfigDropdown extends React.Component<ConfigDropdownProps> {
   private includeArtistsDataCheck = React.createRef<HTMLInputElement>()
   private includeAudioFeaturesDataCheck = React.createRef<HTMLInputElement>()
+  private includeExtendedAlbumDataCheck = React.createRef<HTMLInputElement>()
 
   state = {
     spin: false
@@ -22,7 +23,8 @@ class ConfigDropdown extends React.Component<ConfigDropdownProps> {
     if ((event.target as HTMLElement).nodeName === "INPUT") {
       this.props.onConfigChanged({
         includeArtistsData: this.includeArtistsDataCheck.current?.checked || false,
-        includeAudioFeaturesData: this.includeAudioFeaturesDataCheck.current?.checked || false
+        includeAudioFeaturesData: this.includeAudioFeaturesDataCheck.current?.checked || false,
+        includeExtendedAlbumData: this.includeExtendedAlbumDataCheck.current?.checked || false
       })
     }
   }
@@ -52,6 +54,13 @@ class ConfigDropdown extends React.Component<ConfigDropdownProps> {
               type="switch"
               label="Include audio features data"
               ref={this.includeAudioFeaturesDataCheck}/>
+          </Dropdown.Item>
+          <Dropdown.Item onClickCapture={this.handleCheckClick} as="div">
+            <Form.Check
+              id="config-include-extended-album-data"
+              type="switch"
+              label="Include extended album data"
+              ref={this.includeExtendedAlbumDataCheck}/>
           </Dropdown.Item>
         </Dropdown.Menu>
       </Dropdown>

--- a/src/components/PlaylistExporter.tsx
+++ b/src/components/PlaylistExporter.tsx
@@ -4,6 +4,7 @@ import TracksData from "components/data/TracksData"
 import TracksBaseData from "components/data/TracksBaseData"
 import TracksArtistsData from "components/data/TracksArtistsData"
 import TracksAudioFeaturesData from "components/data/TracksAudioFeaturesData"
+import TracksExtendedAlbumData from "components/data/TracksExtendedAlbumData"
 
 class TracksCsvFile {
   playlist: any
@@ -81,6 +82,11 @@ class PlaylistExporter {
     if (this.config.includeAudioFeaturesData) {
       const tracksAudioFeaturesData = new TracksAudioFeaturesData(this.accessToken, tracks)
       await tracksCsvFile.addData(tracksAudioFeaturesData)
+    }
+
+    if (this.config.includeExtendedAlbumData) {
+      const tracksExtendedAlbumData = new TracksExtendedAlbumData(this.accessToken, tracks)
+      await tracksCsvFile.addData(tracksExtendedAlbumData)
     }
 
     tracksBaseData.tracks()

--- a/src/components/PlaylistTable.jsx
+++ b/src/components/PlaylistTable.jsx
@@ -32,7 +32,8 @@ class PlaylistTable extends React.Component {
     },
     config: {
       includeArtistsData: false,
-      includeAudioFeaturesData: false
+      includeAudioFeaturesData: false,
+      includeExtendedAlbumData: false
     }
   }
 

--- a/src/components/data/TracksExtendedAlbumData.tsx
+++ b/src/components/data/TracksExtendedAlbumData.tsx
@@ -1,0 +1,49 @@
+import TracksData from "./TracksData"
+import { apiCall } from "helpers"
+
+class TracksExtendedAlbumData extends TracksData {
+  ALBUM_LIMIT = 20
+
+  tracks: any[]
+
+  constructor(accessToken: string, tracks: any[]) {
+    super(accessToken)
+    this.tracks = tracks
+  }
+
+  dataLabels() {
+    return ["Album Genres", "Label", "Copyrights"]
+  }
+
+  async data() {
+    const albumIds = Array.from(new Set(this.tracks.map((track: any) => track.album.id)))
+
+    let requests = []
+
+    for (var offset = 0; offset < albumIds.length; offset = offset + this.ALBUM_LIMIT) {
+      requests.push(`https://api.spotify.com/v1/albums?ids=${albumIds.slice(offset, offset + this.ALBUM_LIMIT)}`)
+    }
+
+    const albumPromises = requests.map((request) => apiCall(request, this.accessToken))
+    const albumResponses = await Promise.all(albumPromises)
+
+    const extendedAlbumDataById = new Map<string, string[]>(
+      albumResponses.flatMap((response) => response.data.albums.map((album: any) => {
+        return [
+          album.id,
+          [
+            album.genres.join(", "),
+            album.label,
+            album.copyrights.map((c: any) => `${c.type} ${c.text}`).join(", ")
+          ]
+        ]
+      }))
+    )
+
+    return new Map<string, string[]>(
+      this.tracks.map((track: any) => [track.id, extendedAlbumDataById.get(track.album.id) || ["", "", ""]])
+    )
+  }
+}
+
+export default TracksExtendedAlbumData


### PR DESCRIPTION
Spotify returns "simplified" album objects alongside tracks, but sometimes the [full](https://developer.spotify.com/documentation/web-api/reference/object-model/#album-object-full) album can be useful.

This introduces a new download option, "Include extended album data," which adds columns for album genres, label, and copyrights.

I doubt this will be a very popular option among most users, but I needed to get into the extended data, so I thought I'd share it back.