### PR TITLE
Add japanese and arabic i18n

### DIFF
--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -49,6 +49,14 @@ class TopMenu extends React.Component<TopMenuProps> {
     this.setTheme(this.getPreferredTheme())
   }
 
+  renderLanguageDropdownItem = (language: string, label: string) => (
+    <Dropdown.Item onClick={() => this.handleLanguageSwitch(language)}>
+      <Form.Check type="radio" name="language">
+        <FontAwesomeIcon icon={['fas', 'check']} className={this.props.i18n.language === language ? 'me-1 selected' : 'me-1'} /> {label}
+      </Form.Check>
+    </Dropdown.Item>
+  )
+
   render() {
     const helpButton = this.props.loggedIn ? (
       <>
@@ -118,30 +126,16 @@ class TopMenu extends React.Component<TopMenuProps> {
             <FontAwesomeIcon icon={['fas', 'globe']} />
           </Dropdown.Toggle>
           <Dropdown.Menu>
-            <Dropdown.Item onClick={(event) => this.handleLanguageSwitch("en")}>
-              <Form.Check type="radio" name="language"><FontAwesomeIcon icon={['fas', 'check']} className={this.props.i18n.language === "en" ? 'me-1 selected' : 'me-1'} /> English</Form.Check>
-            </Dropdown.Item>
-            <Dropdown.Item onClick={(event) => this.handleLanguageSwitch("de")}>
-              <Form.Check type="radio" name="language"><FontAwesomeIcon icon={['fas', 'check']} className={this.props.i18n.language === "de" ? 'me-1 selected' : 'me-1'} /> Deutsch</Form.Check>
-            </Dropdown.Item>
-            <Dropdown.Item onClick={(event) => this.handleLanguageSwitch("es")}>
-              <Form.Check type="radio" name="language"><FontAwesomeIcon icon={['fas', 'check']} className={this.props.i18n.language === "es" ? 'me-1 selected' : 'me-1'} /> Español</Form.Check>
-            </Dropdown.Item>
-            <Dropdown.Item onClick={(event) => this.handleLanguageSwitch("fr")}>
-              <Form.Check type="radio" name="language"><FontAwesomeIcon icon={['fas', 'check']} className={this.props.i18n.language === "fr" ? 'me-1 selected' : 'me-1'} /> Français</Form.Check>
-            </Dropdown.Item>
-            <Dropdown.Item onClick={(event) => this.handleLanguageSwitch("it")}>
-              <Form.Check type="radio" name="language"><FontAwesomeIcon icon={['fas', 'check']} className={this.props.i18n.language === "it" ? 'me-1 selected' : 'me-1'} /> Italiano</Form.Check>
-            </Dropdown.Item>
-            <Dropdown.Item onClick={(event) => this.handleLanguageSwitch("nl")}>
-              <Form.Check type="radio" name="language"><FontAwesomeIcon icon={['fas', 'check']} className={this.props.i18n.language === "nl" ? 'me-1 selected' : 'me-1'} /> Nederlands</Form.Check>
-            </Dropdown.Item>
-            <Dropdown.Item onClick={(event) => this.handleLanguageSwitch("pt")}>
-              <Form.Check type="radio" name="language"><FontAwesomeIcon icon={['fas', 'check']} className={this.props.i18n.language === "pt" ? 'me-1 selected' : 'me-1'} /> Português</Form.Check>
-            </Dropdown.Item>
-            <Dropdown.Item onClick={(event) => this.handleLanguageSwitch("sv")}>
-              <Form.Check type="radio" name="language"><FontAwesomeIcon icon={['fas', 'check']} className={this.props.i18n.language === "sv" ? 'me-1 selected' : 'me-1'} /> Svenska</Form.Check>
-            </Dropdown.Item>
+            {this.renderLanguageDropdownItem("en", "English")}
+            {this.renderLanguageDropdownItem("de", "Deutsch")}
+            {this.renderLanguageDropdownItem("es", "Español")}
+            {this.renderLanguageDropdownItem("fr", "Français")}
+            {this.renderLanguageDropdownItem("it", "Italiano")}
+            {this.renderLanguageDropdownItem("nl", "Nederlands")}
+            {this.renderLanguageDropdownItem("pt", "Português")}
+            {this.renderLanguageDropdownItem("sv", "Svenska")}
+            {this.renderLanguageDropdownItem("ar", "العربية")}
+            {this.renderLanguageDropdownItem("ja", "日本語")}
           </Dropdown.Menu>
         </Dropdown>
         {logoutButton}

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -34,6 +34,12 @@ i18n
       },
       sv: {
         translations: require('./locales/sv/translation.json')
+      },
+      ar: {
+        translations: require('./locales/ar/translation.json')
+      },
+      ja: {
+        translations: require('./locales/ja/translation.json')
       }
     },
     ns: ['translations'],

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -1,0 +1,91 @@
+{
+  "tagline": "صدّر قوائم التشغيل الخاصة بك من Spotify.",
+  "get_started": "ابدأ الآن",
+  "subtitle": "{{min}}-{{max}} من {{total}} قوائم التشغيل لـ {{userId}}",
+  "subtitle_search": "{{total}} نتيجة تحتوي على \"{{query}}\" في اسم القائمة",
+  "subtitle_search_advanced": "{{total}} نتيجة للبحث المتقدم \"{{query}}\"",
+  "search": "بحث",
+  "export_all": "تصدير الكل",
+  "exporting_done": "تم التصدير!",
+  "exporting_playlist": "جاري تصدير {{playlistName}}...",
+  "export_search_results": "تصدير النتائج",
+  "top_menu": {
+    "help": "المساعدة",
+    "toggle_dark_mode": "تبديل الوضع الداكن",
+    "change_language": "تغيير اللغة",
+    "change_user": "تبديل المستخدم"
+  },
+  "config": {
+    "include_artists_data": "تضمين بيانات الفنانين",
+    "include_audio_features_data": "تضمين خصائص الصوت",
+    "include_album_data": "تضمين بيانات الألبومات"
+  },
+  "help": {
+    "title": "المرجع السريع",
+    "search_syntax": {
+      "title": "صيغة البحث المتقدم",
+      "query": "الاستعلام",
+      "behavior": "السلوك",
+      "public_true": "عرض قوائم التشغيل العامة فقط",
+      "public_false": "عرض قوائم التشغيل الخاصة فقط",
+      "collaborative_true": "عرض قوائم التشغيل التعاونية فقط",
+      "collaborative_false": "عدم عرض قوائم التشغيل التعاونية",
+      "owner_me": "عرض قوائم التشغيل الخاصة بي فقط",
+      "owner_owner": "عرض قوائم التشغيل المملوكة بواسطة <code>[owner]</code> فقط",
+      "more_detail": "لمزيد من التفاصيل، يرجى الرجوع إلى <a href='https://github.com/watsonbox/exportify' target='_blank' rel='noreferrer'>الوثائق الكاملة للمشروع</a>."
+    }
+  },
+  "playlist": {
+    "name": "الاسم",
+    "owner": "المالك",
+    "tracks": "الأغاني",
+    "public": "عام؟",
+    "collaborative": "تعاوني؟",
+    "not_supported": "هذه القائمة غير مدعومة",
+    "export": "تصدير"
+  },
+  "track": {
+    "track_uri": "رابط الأغنية (URI)",
+    "track_name": "اسم الأغنية",
+    "artist_uris": "روابط الفنانين (URI)",
+    "artist_names": "أسماء الفنانين",
+    "album_uri": "رابط الألبوم (URI)",
+    "album_name": "اسم الألبوم",
+    "album_artist_uris": "روابط فناني الألبوم (URI)",
+    "album_artist_names": "أسماء فناني الألبوم",
+    "album_release_date": "تاريخ إصدار الألبوم",
+    "album_image_url": "رابط صورة الألبوم",
+    "disc_number": "رقم القرص",
+    "track_number": "رقم الأغنية",
+    "track_duration": "مدة الأغنية (بالمللي ثانية)",
+    "track_preview_url": "رابط معاينة الأغنية",
+    "explicit": "صريح",
+    "popularity": "الشعبية",
+    "isrc": "ISRC",
+    "is_playable": "قابل للتشغيل",
+    "added_by": "أضيف بواسطة",
+    "added_at": "أضيف في",
+    "album": {
+      "album_genres": "أنواع الألبوم",
+      "label": "العلامة التجارية",
+      "copyrights": "حقوق النشر"
+    },
+    "artist": {
+      "artist_genres": "أنواع الفنان"
+    },
+    "audio_features": {
+      "danceability": "قابلية الرقص",
+      "energy": "الطاقة",
+      "key": "المفتاح",
+      "loudness": "مستوى الصوت",
+      "mode": "النمط",
+      "speechiness": "محتوى الكلام",
+      "acousticness": "الطابع الصوتي",
+      "instrumentalness": "الطابع الآلي",
+      "liveness": "الحيوية",
+      "valence": "الإيجابية",
+      "tempo": "الإيقاع",
+      "time_signature": "توقيع الزمن"
+    }
+  }
+}

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -1,0 +1,91 @@
+{
+  "tagline": "Spotifyのプレイリストをエクスポートします。",
+  "get_started": "開始する",
+  "subtitle": "{{min}}-{{max}} / {{total}} プレイリスト （ユーザー: {{userId}}）",
+  "subtitle_search": "プレイリスト名に \"{{query}}\" を含む結果: {{total}} 件",
+  "subtitle_search_advanced": "高度なクエリ \"{{query}}\" の結果: {{total}} 件",
+  "search": "検索",
+  "export_all": "すべてエクスポート",
+  "exporting_done": "完了！",
+  "exporting_playlist": "プレイリスト {{playlistName}} をエクスポート中...",
+  "export_search_results": "検索結果をエクスポート",
+  "top_menu": {
+    "help": "ヘルプ",
+    "toggle_dark_mode": "ダークモード切り替え",
+    "change_language": "言語を変更",
+    "change_user": "ユーザーを変更"
+  },
+  "config": {
+    "include_artists_data": "アーティストデータを含める",
+    "include_audio_features_data": "オーディオ機能データを含める",
+    "include_album_data": "アルバムデータを含める"
+  },
+  "help": {
+    "title": "クイックリファレンス",
+    "search_syntax": {
+      "title": "高度な検索構文",
+      "query": "クエリ",
+      "behavior": "動作",
+      "public_true": "公開プレイリストのみを表示",
+      "public_false": "非公開プレイリストのみを表示",
+      "collaborative_true": "共同作成プレイリストのみを表示",
+      "collaborative_false": "共同作成プレイリストを表示しない",
+      "owner_me": "自分が所有するプレイリストのみを表示",
+      "owner_owner": "<code>[owner]</code> が所有するプレイリストのみを表示",
+      "more_detail": "詳細は<a href='https://github.com/watsonbox/exportify' target='_blank' rel='noreferrer'>完全なプロジェクトドキュメント</a>をご覧ください。"
+    }
+  },
+  "playlist": {
+    "name": "名前",
+    "owner": "所有者",
+    "tracks": "トラック数",
+    "public": "公開？",
+    "collaborative": "共同作成？",
+    "not_supported": "このプレイリストはサポートされていません",
+    "export": "エクスポート"
+  },
+  "track": {
+    "track_uri": "トラックURI",
+    "track_name": "トラック名",
+    "artist_uris": "アーティストURI",
+    "artist_names": "アーティスト名",
+    "album_uri": "アルバムURI",
+    "album_name": "アルバム名",
+    "album_artist_uris": "アルバムアーティストURI",
+    "album_artist_names": "アルバムアーティスト名",
+    "album_release_date": "アルバム発売日",
+    "album_image_url": "アルバム画像URL",
+    "disc_number": "ディスク番号",
+    "track_number": "トラック番号",
+    "track_duration": "トラックの長さ（ミリ秒）",
+    "track_preview_url": "トラックプレビューURL",
+    "explicit": "明示的な内容",
+    "popularity": "人気度",
+    "isrc": "ISRC",
+    "is_playable": "再生可能",
+    "added_by": "追加者",
+    "added_at": "追加日時",
+    "album": {
+      "album_genres": "アルバムジャンル",
+      "label": "レーベル",
+      "copyrights": "著作権"
+    },
+    "artist": {
+      "artist_genres": "アーティストジャンル"
+    },
+    "audio_features": {
+      "danceability": "ダンサビリティ",
+      "energy": "エネルギー",
+      "key": "キー",
+      "loudness": "ラウドネス",
+      "mode": "モード",
+      "speechiness": "スピーチ性",
+      "acousticness": "アコースティック性",
+      "instrumentalness": "インストゥルメンタル性",
+      "liveness": "ライブ感",
+      "valence": "感情値",
+      "tempo": "テンポ",
+      "time_signature": "拍子"
+    }
+  }
+}


### PR DESCRIPTION
- Added Japanese and Arabic translations to the app's i18n setup. 
- Refactored the language dropdown to use a reusable render function for better scalability and maintainability, including the new language options.