### PR TITLE
fix: resolve owner search filter not working (#196)

### DIFF
--- a/src/components/data/PlaylistsData.ts
+++ b/src/components/data/PlaylistsData.ts
@@ -64,7 +64,7 @@ class PlaylistsData {
       let owner = query.match(/owner:(.*)/)?.at(-1)?.toLowerCase()
       if (owner === "me") owner = this.userId
 
-      return results.filter(p => p.owner).filter(p => p.owner.display_name.toLowerCase() === owner)
+      return results.filter(p => p.owner).filter(p => p.owner.id === owner)
     } else {
       // Case-insensitive search in playlist name
       // TODO: Add lazy evaluation for performance?


### PR DESCRIPTION
## Fix #196: `owner:me` filter not working in search

### Description
The `owner:me` filter was not functioning in the search, while other filters worked correctly.

### Changes
- Updated comparison logic to use `p.owner.id === owner`.

### Testing
- Verified locally; the `owner:me` filter now works as expected.