### PR TITLE
Implement saved album exporting

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -51,6 +51,10 @@
   }
 }
 
+#saved-albums {
+  animation: fadeIn 1s;
+}
+
 #playlists {
   animation: fadeIn 1s;
 
@@ -140,19 +144,17 @@
 }
 
 .spinner {
-  min-width: 24px;
-  min-height: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100px;
+  margin: 12px;
 }
 
 .spinner:before {
   content: 'Loading…';
-  position: absolute;
-  top: 240px;
-  left: 50%;
   width: 100px;
   height: 100px;
-  margin-top: -50px;
-  margin-left: -50px;
 }
 
 .spinner:not(:required):before {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import "url-search-params-polyfill"
 
 import Login from 'components/Login'
 import PlaylistTable from "components/PlaylistTable"
+import SavedAlbumRow from "components/SavedAlbumRow"
 import TopMenu from "components/TopMenu"
 import { loadAccessToken, exchangeCodeForToken } from "auth"
 
@@ -50,7 +51,10 @@ function App() {
       <p style={{ marginTop: "50px" }}>Keep an eye on the <a target="_blank" rel="noreferrer" href="https://status.spotify.dev/">Spotify Web API Status page</a> to see if there are any known problems right now, and then <a rel="noreferrer" href="?">retry</a>.</p>
     </div>
   } else if (accessToken) {
-    view = <PlaylistTable accessToken={accessToken!} onSetSubtitle={onSetSubtitle} />
+    view = <>
+      <PlaylistTable accessToken={accessToken!} onSetSubtitle={onSetSubtitle} />
+      <SavedAlbumRow accessToken={accessToken!} />
+    </>
   } else {
     view = <Login />
   }

--- a/src/components/PlaylistTable.tsx
+++ b/src/components/PlaylistTable.tsx
@@ -14,7 +14,7 @@ import { apiCall, apiCallErrorHandler } from "helpers"
 interface PlaylistTableProps extends WithTranslation {
   accessToken: string,
   config?: any,
-  onSetSubtitle: (subtitile: React.JSX.Element) => void
+  onSetSubtitle: (subtitile: React.JSX.Element) => void,
 }
 
 class PlaylistTable extends React.Component<PlaylistTableProps> {

--- a/src/components/PlaylistTable.tsx
+++ b/src/components/PlaylistTable.tsx
@@ -14,7 +14,7 @@ import { apiCall, apiCallErrorHandler } from "helpers"
 interface PlaylistTableProps extends WithTranslation {
   accessToken: string,
   config?: any,
-  onSetSubtitle: (subtitile: React.JSX.Element) => void,
+  onSetSubtitle: (subtitile: React.JSX.Element) => void
 }
 
 class PlaylistTable extends React.Component<PlaylistTableProps> {

--- a/src/components/SavedAlbumExporter.tsx
+++ b/src/components/SavedAlbumExporter.tsx
@@ -1,0 +1,41 @@
+import { saveAs } from "file-saver";
+import SavedAlbumData from "./data/SavedAlbumData";
+
+// Handles exporting all of a user's saved albums as a CSV file
+class SavedAlbumExporter {
+  FILE_NAME = "saved_albums.csv"
+
+  accessToken: string
+  savedAlbumCount: number
+
+  constructor(accessToken: string, savedAlbumCount: number) {
+    this.accessToken = accessToken
+    this.savedAlbumCount = savedAlbumCount
+  }
+
+  async export() {
+    return this.csvData().then((data) => {
+      const blob = new Blob([data], { type: "text/csv;charset=utf-8" })
+      saveAs(blob, this.FILE_NAME, { autoBom: false })
+    })
+  }
+
+  async csvData() {
+    const savedAlbumData = new SavedAlbumData(this.accessToken, this.savedAlbumCount)
+    const items = await savedAlbumData.data()
+
+    let csvContent = ""
+    csvContent += savedAlbumData.dataLabels().map(this.sanitize).join() + "\n"
+    items.forEach((albumData) => {
+      csvContent += albumData.map(this.sanitize).join(",") + "\n"
+    })
+
+    return csvContent
+  }
+
+  sanitize(string: string): string {
+    return '"' + String(string).replace(/"/g, '""') + '"'
+  }
+}
+
+export default SavedAlbumExporter

--- a/src/components/SavedAlbumExporter.tsx
+++ b/src/components/SavedAlbumExporter.tsx
@@ -7,10 +7,12 @@ class SavedAlbumExporter {
 
   accessToken: string
   savedAlbumCount: number
+  onPageFetched: (albumsFetched: number) => void
 
-  constructor(accessToken: string, savedAlbumCount: number) {
+  constructor(accessToken: string, savedAlbumCount: number, onPageFetched: (albumsFetched: number) => void) {
     this.accessToken = accessToken
     this.savedAlbumCount = savedAlbumCount
+    this.onPageFetched = onPageFetched
   }
 
   async export() {
@@ -21,7 +23,7 @@ class SavedAlbumExporter {
   }
 
   async csvData() {
-    const savedAlbumData = new SavedAlbumData(this.accessToken, this.savedAlbumCount)
+    const savedAlbumData = new SavedAlbumData(this.accessToken, this.savedAlbumCount, this.onPageFetched)
     const items = await savedAlbumData.data()
 
     let csvContent = ""

--- a/src/components/SavedAlbumRow.scss
+++ b/src/components/SavedAlbumRow.scss
@@ -17,3 +17,18 @@
     margin-left: auto;
   }
 }
+
+#saved-album-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  h4 {
+    margin: 0;
+    white-space: nowrap;
+  }
+
+  .progress {
+    flex: 1;
+  }
+}

--- a/src/components/SavedAlbumRow.scss
+++ b/src/components/SavedAlbumRow.scss
@@ -1,0 +1,19 @@
+@import "../index.scss";
+
+#saved-album-row {
+  display: flex;
+  align-items: center;
+  padding: 8px;
+  gap: 12px;
+
+  margin-top: 16px;
+  margin-bottom: 32px;
+
+  &:hover {
+    background-color: $table-hover-bg;
+  }
+
+  button {
+    margin-left: auto;
+  }
+}

--- a/src/components/SavedAlbumRow.test.tsx
+++ b/src/components/SavedAlbumRow.test.tsx
@@ -1,0 +1,124 @@
+import React from "react"
+import "i18n/config"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { setupServer } from "msw/node"
+import FileSaver from "file-saver"
+
+import SavedAlbumRow from "./SavedAlbumRow"
+
+import "../icons"
+import { handlerCalled, handlers } from "../mocks/handlers"
+
+const server = setupServer(...handlers)
+
+// Mock out Bugsnag calls
+jest.mock('@bugsnag/js')
+
+server.listen({
+  onUnhandledRequest: 'warn'
+})
+
+beforeAll(() => {
+  // @ts-ignore
+  global.Blob = function (content, options) { return ({ content, options }) }
+
+  // https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(), // Deprecated
+      removeListener: jest.fn(), // Deprecated
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+})
+
+const { location } = window
+
+beforeAll(() => {
+  // @ts-ignore
+  delete window.location
+})
+
+afterAll(() => {
+  window.location = location
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+  server.resetHandlers()
+})
+
+const baseAlbumHeaders = '"Album URI","Album Name","Album Type","Album Artist URI(s)","Album Artist Name(s)","Album Release Date","Release Date Precision","Track Count","Saved At"'
+
+// Use a snapshot test to ensure exact component rendering
+test("saved album row loading", async () => {
+  const { asFragment } = render(<SavedAlbumRow accessToken="TEST_ACCESS_TOKEN" />)
+
+  expect(await screen.findByText(/Saved albums/)).toBeInTheDocument()
+
+  expect(asFragment()).toMatchSnapshot();
+})
+
+test("redirecting when access token is invalid", async () => {
+  // @ts-ignore
+  window.location = { pathname: "/exportify", href: "http://www.example.com/exportify" }
+
+  render(<SavedAlbumRow accessToken="INVALID_ACCESS_TOKEN" />)
+
+  await waitFor(() => {
+    expect(window.location.href).toBe("/exportify")
+  })
+})
+
+test("standard case exports successfully", async () => {
+  const saveAsMock = jest.spyOn(FileSaver, "saveAs")
+  saveAsMock.mockImplementation(jest.fn())
+
+  render(<SavedAlbumRow accessToken="TEST_ACCESS_TOKEN" />);
+
+  expect(await screen.findByText(/Saved albums/)).toBeInTheDocument()
+
+  const buttonElement = screen.getByRole("button", { name: /export/i })
+
+  expect(buttonElement).toBeInTheDocument()
+
+  await userEvent.click(buttonElement)
+
+  await waitFor(() => {
+    expect(buttonElement).toHaveAttribute("disabled")
+  })
+
+  await waitFor(() => {
+    expect(handlerCalled.mock.calls).toContainEqual(
+      ['https://api.spotify.com/v1/me/albums?limit=50&offset=0']
+    )
+  })
+
+  await waitFor(() => {
+    expect(saveAsMock).toHaveBeenCalledTimes(1)
+  })
+
+  expect(saveAsMock).toHaveBeenCalledWith(
+    {
+      content: [
+        `${baseAlbumHeaders}\n` +
+        `"spotify:album:4iwv7b8gDPKztLkKCbWyhi","Best of Six By Seven","album","spotify:artist:4TXdHyuAOl3rAOFmZ6MeKz","Six by Seven","2017-02-17","day","14","2020-07-19T09:24:39Z"\n` +
+        `"spotify:album:4MxbRuLNbxf0RERbT8OHsU","Cinder","album","spotify:artist:6H9oDpJUDuw3nkogwhd21s","Lux Terminus","2025-04-18","day","10","2025-04-23T14:51:45Z"\n` +
+        `"spotify:album:7aIEHWiuOkDywdjyQyt8CL","program music II","album","spotify:artist:5sGsy5o8hBSMmDUFTC5Q2P","KASHIWA Daisuke","2016-04-30","day","8","2025-11-25T18:26:03Z"\n` +
+        `"spotify:album:3xOcExpIWzroZldcdc212q","The Overview","album","spotify:artist:4X42BfuhWCAZ2swiVze9O0","Steven Wilson","2025-03-14","day","12","2025-03-20T21:24:38Z"\n` +
+        `"spotify:album:6azzagF3oeYffG22gIiLWz","Nocturne","album","spotify:artist:2SDGIFzEh9xmE5zDKcMRkj","The Human Abstract","2006-08-22","day","12","2025-11-25T00:41:40Z"\n` +
+        `"spotify:album:4abjNrXQcMRQlm0O4iyUSZ","Digital Veil","album","spotify:artist:2SDGIFzEh9xmE5zDKcMRkj","The Human Abstract","2011-03-08","day","8","2025-11-24T23:54:26Z"\n`
+      ],
+      options: { type: 'text/csv;charset=utf-8' }
+    },
+    'saved_albums.csv',
+    { "autoBom": false }
+  )
+})

--- a/src/components/SavedAlbumRow.tsx
+++ b/src/components/SavedAlbumRow.tsx
@@ -34,11 +34,11 @@ class SavedAlbumRow extends React.Component<SavedAlbumRowProps> {
         }),
         value: albumsFetched,
       },
-    });
+    })
   }
 
   exportAlbums = () => {
-    Bugsnag.leaveBreadcrumb("Started exporting all saved albums");
+    Bugsnag.leaveBreadcrumb("Started exporting all saved albums")
     this.setState(
       {
         exporting: true,
@@ -68,10 +68,10 @@ class SavedAlbumRow extends React.Component<SavedAlbumRowProps> {
                 label: "",
                 value: 0,
               },
-            });
-          });
+            })
+          })
       }
-    );
+    )
   }
 
   // We make one 'dummy' call to the user's saved album API to get the count
@@ -102,7 +102,7 @@ class SavedAlbumRow extends React.Component<SavedAlbumRowProps> {
         max={this.state.savedAlbumCount}
         label={this.state.progressBar.label}
       />
-    );
+    )
 
     if (this.state.initialized) {
       return (

--- a/src/components/SavedAlbumRow.tsx
+++ b/src/components/SavedAlbumRow.tsx
@@ -112,7 +112,7 @@ class SavedAlbumRow extends React.Component<SavedAlbumRowProps> {
           </div>
           <div id="saved-album-row">
             <FontAwesomeIcon icon={["fas", "record-vinyl"]} size="lg" />
-            <span>{this.state.savedAlbumCount} saved albums</span>
+            <span>{this.state.savedAlbumCount} saved album(s)</span>
             {/* @ts-ignore */}
             <Button type="submit" variant="primary" size="xs" onClick={this.exportAlbums} disabled={this.state.exporting} className="text-nowrap">
               {/* @ts-ignore */}

--- a/src/components/SavedAlbumRow.tsx
+++ b/src/components/SavedAlbumRow.tsx
@@ -1,0 +1,87 @@
+import "./SavedAlbumRow.scss";
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { apiCall, apiCallErrorHandler } from "helpers";
+import React from "react";
+import { Button, ProgressBar } from "react-bootstrap";
+import { withTranslation, WithTranslation } from "react-i18next";
+import SavedAlbumExporter from "./SavedAlbumExporter";
+
+interface SavedAlbumRowProps extends WithTranslation {
+  accessToken: string
+}
+
+class SavedAlbumRow extends React.Component<SavedAlbumRowProps> {
+  state = {
+    initialized: false,
+    exporting: false,
+    savedAlbumCount: 0,
+    progressBar: {
+      show: false,
+      label: "",
+      value: 0
+    },
+  }
+
+  exportAlbums = () => {
+    this.setState({ exporting: true }, () => {
+      new SavedAlbumExporter(this.props.accessToken, this.state.savedAlbumCount)
+        .export()
+        .catch(apiCallErrorHandler)
+        .then(() => {
+          this.setState({ exporting: false });
+        })
+    })
+  }
+
+  // We make one 'dummy' call to the user's saved album API to get the count
+  async componentDidMount() {
+    try {
+      const res = await apiCall(
+        `https://api.spotify.com/v1/me/albums?limit=1`,
+        this.props.accessToken
+      ).then((response) => response.data)
+
+      this.setState({
+        savedAlbumCount: res.total,
+        initialized: true,
+      })
+    } catch (error) {
+      apiCallErrorHandler(error)
+    }
+  }
+
+  render() {
+    const icon = ["fas", this.state.exporting ? "sync" : "download"]
+    const progressBar = (
+      <ProgressBar
+        striped
+        variant="primary"
+        animated={this.state.progressBar.value < this.state.savedAlbumCount}
+        now={this.state.progressBar.value}
+        max={this.state.savedAlbumCount}
+      />
+    );
+
+    if (this.state.initialized) {
+      return (
+        <div id="saved-albums">
+          <h4>Saved albums</h4>
+          <div id="saved-album-row">
+            <FontAwesomeIcon icon={["fas", "record-vinyl"]} size="lg" />
+            <span>{this.state.savedAlbumCount} saved albums</span>
+            {/* @ts-ignore */}
+            <Button type="submit" variant="primary" size="xs" onClick={this.exportAlbums} disabled={this.state.exporting} className="text-nowrap">
+              {/* @ts-ignore */}
+              <FontAwesomeIcon icon={icon} size="sm" spin={this.state.exporting} /> {this.props.i18n.t("playlist.export")}
+            </Button>
+          </div>
+        </div>
+      )
+    } else {
+      return <div className="spinner" data-testid="savedAlbumRowSpinner"></div>
+    }
+  }
+}
+
+export default withTranslation()(SavedAlbumRow)

--- a/src/components/__snapshots__/SavedAlbumRow.test.tsx.snap
+++ b/src/components/__snapshots__/SavedAlbumRow.test.tsx.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`saved album row loading 1`] = `
+<DocumentFragment>
+  <div
+    id="saved-albums"
+  >
+    <div
+      id="saved-album-header"
+    >
+      <h4>
+        Saved albums
+      </h4>
+       
+    </div>
+    <div
+      id="saved-album-row"
+    >
+      <svg
+        aria-hidden="true"
+        class="svg-inline--fa fa-record-vinyl fa-lg "
+        data-icon="record-vinyl"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        viewBox="0 0 512 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256zm256-96a96 96 0 1 1 0 192 96 96 0 1 1 0-192zm0 224a128 128 0 1 0 0-256 128 128 0 1 0 0 256zm0-96a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"
+          fill="currentColor"
+        />
+      </svg>
+      <span>
+        1 saved album(s)
+      </span>
+      <button
+        class="text-nowrap btn btn-primary btn-xs"
+        type="submit"
+      >
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-download fa-sm "
+          data-icon="download"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M288 32c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 242.7-73.4-73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l128 128c12.5 12.5 32.8 12.5 45.3 0l128-128c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L288 274.7 288 32zM64 352c-35.3 0-64 28.7-64 64l0 32c0 35.3 28.7 64 64 64l384 0c35.3 0 64-28.7 64-64l0-32c0-35.3-28.7-64-64-64l-101.5 0-45.3 45.3c-25 25-65.5 25-90.5 0L165.5 352 64 352zm368 56a24 24 0 1 1 0 48 24 24 0 1 1 0-48z"
+            fill="currentColor"
+          />
+        </svg>
+         Export
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/data/SavedAlbumData.ts
+++ b/src/components/data/SavedAlbumData.ts
@@ -31,7 +31,7 @@ class SavedAlbumData {
     ]
   }
 
-  private savedAlbumItems: any[] = [];
+  private savedAlbumItems: any[] = []
   async fetchSavedAlbumItems() {
     if (this.savedAlbumItems.length > 0) {
       return this.savedAlbumItems

--- a/src/components/data/SavedAlbumData.ts
+++ b/src/components/data/SavedAlbumData.ts
@@ -1,0 +1,86 @@
+import { apiCall } from "helpers";
+import i18n from "i18n/config";
+
+class SavedAlbumData {
+  private accessToken: string
+
+  /**
+   * we fetch this count on initial load of App.tsx. We need it here to calculate how many 
+   * pages of requests we need to make
+   */
+  private savedAlbumCount: number
+
+  constructor(accessToken: string, savedAlbumCount: number) {
+    this.accessToken = accessToken
+    this.savedAlbumCount = savedAlbumCount
+  }
+
+  dataLabels() {
+    return [
+      i18n.t("album.album_uri"),
+      i18n.t("album.album_name"),
+      i18n.t("album.album_type"),
+      i18n.t("album.album_artist_uris"),
+      i18n.t("album.album_artist_names"),
+      i18n.t("album.album_release_date"),
+      i18n.t("album.album_release_date_precision"),
+      i18n.t("album.album_track_count"),
+      i18n.t("album.saved_at"),
+    ]
+  }
+
+  private savedAlbumItems: any[] = [];
+  async fetchSavedAlbumItems() {
+    if (this.savedAlbumItems.length > 0) {
+      return this.savedAlbumItems
+    }
+    const requests = []
+    const limit = 50 // max allowed by spotify API
+
+    for (let offset = 0; offset < this.savedAlbumCount; offset = offset + limit) {
+      requests.push(`https://api.spotify.com/v1/me/albums?limit=${limit}&offset=${offset}`)
+    }
+
+    const albumPromises = requests.map((request) => {
+      return apiCall(request, this.accessToken)
+    })
+    const albumResponses = await Promise.all(albumPromises)
+    this.savedAlbumItems = albumResponses.flatMap((response) => {
+      return response.data.items.filter((i: any) => i.album)
+    })
+    return this.savedAlbumItems
+  }
+
+  async data() {
+    await this.fetchSavedAlbumItems()
+
+    return new Map(
+      this.savedAlbumItems.map((item) => {
+        return [
+          item.album.uri,
+          [
+            item.album.uri,
+            item.album.name,
+            item.album.album_type,
+            item.album.artists
+              .map((a: any) => {
+                return a.uri;
+              })
+              .join(", "),
+            item.album.artists
+              .map((a: any) => {
+                return String(a.name).replace(/,/g, "\\,");
+              })
+              .join(", "),
+            item.album.release_date,
+            item.album.release_date_precision,
+            item.album.tracks.total,
+            item.added_at
+          ],
+        ]
+      })
+    )
+  }
+}
+
+export default SavedAlbumData

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -87,5 +87,16 @@
       "tempo": "Tempo",
       "time_signature": "Time Signature"
     }
+  },
+  "album": {
+    "album_uri": "Album URI",
+    "album_name": "Album Name",
+    "album_type": "Album Type",
+    "album_artist_uris": "Album Artist URI(s)",
+    "album_artist_names": "Album Artist Name(s)",
+    "album_release_date": "Album Release Date",
+    "album_release_date_precision": "Release Date Precision",
+    "album_track_count": "Track Count",
+    "saved_at": "Saved At"
   }
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -8,6 +8,7 @@
   "export_all": "Export All",
   "exporting_done": "Done!",
   "exporting_playlist": "Exporting {{playlistName}}...",
+  "exporting_saved_albums": "Exporting saved albums... ({{fetched}}/{{total}})",
   "export_search_results": "Export Results",
   "top_menu": {
     "help": "Help",

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -1,7 +1,7 @@
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { fab } from '@fortawesome/free-brands-svg-icons'
 import { faCheckCircle, faTimesCircle, faFileArchive, faHeart } from '@fortawesome/free-regular-svg-icons'
-import { faBolt, faMusic, faDownload, faCog, faSearch, faTimes, faSignOutAlt, faSync, faLightbulb, faCircleInfo, faGlobe, faCheck } from '@fortawesome/free-solid-svg-icons'
+import { faBolt, faMusic, faDownload, faCog, faSearch, faTimes, faSignOutAlt, faSync, faLightbulb, faCircleInfo, faGlobe, faCheck, faRecordVinyl } from '@fortawesome/free-solid-svg-icons'
 
 library.add(
   fab,
@@ -20,5 +20,6 @@ library.add(
   faLightbulb,
   faCircleInfo,
   faGlobe,
-  faCheck
+  faCheck,
+  faRecordVinyl
 )

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -546,6 +546,217 @@ export const handlers = [
     ))
   }),
 
+  rest.get('https://api.spotify.com/v1/me/albums', (req, res, ctx) => {
+    handlerCalled(req.url.toString())
+
+    if (req.headers.get("Authorization") !== "Bearer TEST_ACCESS_TOKEN") {
+      return res(ctx.status(401), ctx.json({ message: 'Not authorized' }))
+    }
+
+    // Initial count request
+    if (req.url.searchParams.get('limit') === "1") {
+      return res(ctx.json(
+        {
+          "href": "https://api.spotify.com/v1/me/albums?limit=1",
+          "items": [{
+            "added_at": "2020-07-19T09:24:39Z",
+            "album": {
+              "album_type": "album",
+              "artists": [{
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/4TXdHyuAOl3rAOFmZ6MeKz"
+                },
+                "href": "https://api.spotify.com/v1/artists/4TXdHyuAOl3rAOFmZ6MeKz",
+                "id": "4TXdHyuAOl3rAOFmZ6MeKz",
+                "name": "Six by Seven",
+                "type": "artist",
+                "uri": "spotify:artist:4TXdHyuAOl3rAOFmZ6MeKz"
+              }],
+              "href": "https://api.spotify.com/v1/albums/4iwv7b8gDPKztLkKCbWyhi",
+              "id": "4iwv7b8gDPKztLkKCbWyhi",
+              "name": "Best of Six By Seven",
+              "release_date": "2017-02-17",
+              "release_date_precision": "day",
+              "tracks": {
+                "total": 14
+              },
+              "type": "album",
+              "uri": "spotify:album:4iwv7b8gDPKztLkKCbWyhi"
+            }
+          }],
+          "limit": 1,
+          "next": null,
+          "offset": 0,
+          "previous": null,
+          "total": 1
+        }
+      ))
+    }
+
+    // Paginated album fetch
+    return res(ctx.json(
+      {
+        "href": "https://api.spotify.com/v1/me/albums?limit=50&offset=0",
+        "items": [{
+          "added_at": "2020-07-19T09:24:39Z",
+          "album": {
+            "album_type": "album",
+            "artists": [{
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4TXdHyuAOl3rAOFmZ6MeKz"
+              },
+              "href": "https://api.spotify.com/v1/artists/4TXdHyuAOl3rAOFmZ6MeKz",
+              "id": "4TXdHyuAOl3rAOFmZ6MeKz",
+              "name": "Six by Seven",
+              "type": "artist",
+              "uri": "spotify:artist:4TXdHyuAOl3rAOFmZ6MeKz"
+            }],
+            "href": "https://api.spotify.com/v1/albums/4iwv7b8gDPKztLkKCbWyhi",
+            "id": "4iwv7b8gDPKztLkKCbWyhi",
+            "name": "Best of Six By Seven",
+            "release_date": "2017-02-17",
+            "release_date_precision": "day",
+            "tracks": {
+              "total": 14
+            },
+            "type": "album",
+            "uri": "spotify:album:4iwv7b8gDPKztLkKCbWyhi"
+          }
+        }, {
+          "added_at": "2025-04-23T14:51:45Z",
+          "album": {
+            "album_type": "album",
+            "artists": [{
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/6H9oDpJUDuw3nkogwhd21s"
+              },
+              "href": "https://api.spotify.com/v1/artists/6H9oDpJUDuw3nkogwhd21s",
+              "id": "6H9oDpJUDuw3nkogwhd21s",
+              "name": "Lux Terminus",
+              "type": "artist",
+              "uri": "spotify:artist:6H9oDpJUDuw3nkogwhd21s"
+            }],
+            "href": "https://api.spotify.com/v1/albums/4MxbRuLNbxf0RERbT8OHsU",
+            "id": "4MxbRuLNbxf0RERbT8OHsU",
+            "name": "Cinder",
+            "release_date": "2025-04-18",
+            "release_date_precision": "day",
+            "tracks": {
+              "total": 10
+            },
+            "type": "album",
+            "uri": "spotify:album:4MxbRuLNbxf0RERbT8OHsU"
+          }
+        }, {
+          "added_at": "2025-11-25T18:26:03Z",
+          "album": {
+            "album_type": "album",
+            "artists": [{
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5sGsy5o8hBSMmDUFTC5Q2P"
+              },
+              "href": "https://api.spotify.com/v1/artists/5sGsy5o8hBSMmDUFTC5Q2P",
+              "id": "5sGsy5o8hBSMmDUFTC5Q2P",
+              "name": "KASHIWA Daisuke",
+              "type": "artist",
+              "uri": "spotify:artist:5sGsy5o8hBSMmDUFTC5Q2P"
+            }],
+            "href": "https://api.spotify.com/v1/albums/7aIEHWiuOkDywdjyQyt8CL",
+            "id": "7aIEHWiuOkDywdjyQyt8CL",
+            "name": "program music II",
+            "release_date": "2016-04-30",
+            "release_date_precision": "day",
+            "tracks": {
+              "total": 8
+            },
+            "type": "album",
+            "uri": "spotify:album:7aIEHWiuOkDywdjyQyt8CL"
+          }
+        }, {
+          "added_at": "2025-03-20T21:24:38Z",
+          "album": {
+            "album_type": "album",
+            "artists": [{
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/4X42BfuhWCAZ2swiVze9O0"
+              },
+              "href": "https://api.spotify.com/v1/artists/4X42BfuhWCAZ2swiVze9O0",
+              "id": "4X42BfuhWCAZ2swiVze9O0",
+              "name": "Steven Wilson",
+              "type": "artist",
+              "uri": "spotify:artist:4X42BfuhWCAZ2swiVze9O0"
+            }],
+            "href": "https://api.spotify.com/v1/albums/3xOcExpIWzroZldcdc212q",
+            "id": "3xOcExpIWzroZldcdc212q",
+            "name": "The Overview",
+            "release_date": "2025-03-14",
+            "release_date_precision": "day",
+            "tracks": {
+              "total": 12
+            },
+            "type": "album",
+            "uri": "spotify:album:3xOcExpIWzroZldcdc212q"
+          }
+        }, {
+          "added_at": "2025-11-25T00:41:40Z",
+          "album": {
+            "album_type": "album",
+            "artists": [{
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2SDGIFzEh9xmE5zDKcMRkj"
+              },
+              "href": "https://api.spotify.com/v1/artists/2SDGIFzEh9xmE5zDKcMRkj",
+              "id": "2SDGIFzEh9xmE5zDKcMRkj",
+              "name": "The Human Abstract",
+              "type": "artist",
+              "uri": "spotify:artist:2SDGIFzEh9xmE5zDKcMRkj"
+            }],
+            "href": "https://api.spotify.com/v1/albums/6azzagF3oeYffG22gIiLWz",
+            "id": "6azzagF3oeYffG22gIiLWz",
+            "name": "Nocturne",
+            "release_date": "2006-08-22",
+            "release_date_precision": "day",
+            "tracks": {
+              "total": 12
+            },
+            "type": "album",
+            "uri": "spotify:album:6azzagF3oeYffG22gIiLWz"
+          }
+        }, {
+          "added_at": "2025-11-24T23:54:26Z",
+          "album": {
+            "album_type": "album",
+            "artists": [{
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/2SDGIFzEh9xmE5zDKcMRkj"
+              },
+              "href": "https://api.spotify.com/v1/artists/2SDGIFzEh9xmE5zDKcMRkj",
+              "id": "2SDGIFzEh9xmE5zDKcMRkj",
+              "name": "The Human Abstract",
+              "type": "artist",
+              "uri": "spotify:artist:2SDGIFzEh9xmE5zDKcMRkj"
+            }],
+            "href": "https://api.spotify.com/v1/albums/4abjNrXQcMRQlm0O4iyUSZ",
+            "id": "4abjNrXQcMRQlm0O4iyUSZ",
+            "name": "Digital Veil",
+            "release_date": "2011-03-08",
+            "release_date_precision": "day",
+            "tracks": {
+              "total": 8
+            },
+            "type": "album",
+            "uri": "spotify:album:4abjNrXQcMRQlm0O4iyUSZ"
+          }
+        }],
+        "limit": 50,
+        "next": null,
+        "offset": 0,
+        "previous": null,
+        "total": 6
+      }
+    ))
+  }),
+
   rest.get('https://api.spotify.com/v1/albums', (req, res, ctx) => {
     handlerCalled(req.url.toString())
 


### PR DESCRIPTION
I've seen this feature requested several times over the years. I'm in the camp of people who don't use playlists much, but would greatly benefit from having my saved album data be portable, so I decided to take a stab at contributing onto this project.

This PR adds an extra section to the bottom of the page, showing the user their count of saved albums. An export button is provided that will allow the user to download a CSV data dump of the saved albums
<img width="1095" height="379" alt="image" src="https://github.com/user-attachments/assets/c647b055-d42d-4bd3-856b-ee9759c19be9" />
<img width="1502" height="469" alt="image" src="https://github.com/user-attachments/assets/c4cdfc15-0192-464b-953f-68b49dcedbba" />


From a UI perspective I did my best to give it continuity with the rest of the page. The row has a soft highlight when you mouse over it, the button disables and the icon spins when an export is in progress, and a progress bar shows the user how far along the export is:
<img width="1099" height="149" alt="image" src="https://github.com/user-attachments/assets/8e369dd4-213d-43dd-8fd8-43e9f768986c" />

I tried to avoid touching existing pieces if possible, but I did make a minor change to the behavior of the spinner while initialization of the first page of playlists is in progress. Previously, the spinner was an absolutely positioned element outside the flow of the page. My new component has no awareness of the state of the playlist component, so it would often finish loading first and appear under the playlist spinner, which seemed not ideal. I changed the spinner to appear inline within its container, and also gave a spinner to the new album component, and they load in independently when they are ready.
<img width="1127" height="563" alt="image" src="https://github.com/user-attachments/assets/b793ead2-caf1-4f44-8d66-4ec10d67284b" />
<img width="1124" height="488" alt="image" src="https://github.com/user-attachments/assets/2ef8a5d1-f665-433f-a103-105708c23057" />

There is also some duplication with the translation strings. Many of the column headers could re-use column headers from the track object, but it also seemed reasonable to treat 'album' as its own new object and give it its own strings. Past experience made me lean this way, as the different context might result in different translations in other languages, despite being the same in english. If you prefer to optimize for re-use, let me know and I will do so.

Thanks in advance for your review!